### PR TITLE
Add set_interface/get_interface

### DIFF
--- a/facedancer/USBInterface.py
+++ b/facedancer/USBInterface.py
@@ -44,6 +44,7 @@ class USBInterface(USBDescribable):
 
         self.request_handlers = {
              6 : self.handle_get_descriptor_request,
+            10 : self.handle_get_interface_request,
             11 : self.handle_set_interface_request
         }
 
@@ -141,8 +142,12 @@ class USBInterface(USBDescribable):
             if self.verbose > 5:
                 print(self.name, "sent", n, "bytes in response")
 
+    def handle_get_interface_request(self, req):
+        self.configuration.device.maxusb_app.send_on_endpoint(0, self.alternate)
+
     def handle_set_interface_request(self, req):
-        self.configuration.device.maxusb_app.stall_ep0()
+        self.alternate = req.value
+        self.configuration.device.maxusb_app.send_on_endpoint(0, b'')
 
     # Table 9-12 of USB 2.0 spec (pdf page 296)
     def get_descriptor(self):


### PR DESCRIPTION
Linux USB printer driver always sends set_interface even when there is only one and no alternate.

```
0x01,       // bmRequestType: Dir: H2D, Type: Standard, Recipient: Interface
0x0B,       // bRequest (Set Interface)
0x00, 0x00, // wValue Alt Setting: 0
0x00, 0x00, // wIndex Interface: 0
0x00, 0x00, // wLength = 0
```