### PR TITLE
Endpoint/Interface specific Requests were not handled by correct handler function

### DIFF
--- a/facedancer/future/device.py
+++ b/facedancer/future/device.py
@@ -21,6 +21,7 @@ from .magic         import instantiate_subordinates
 
 from .descriptor    import USBDescribable, USBDescriptor, StringDescriptorManager
 from .configuration import USBConfiguration
+from .interface     import USBInterface
 from .endpoint      import USBEndpoint
 from .request       import USBControlRequest, USBRequestHandler
 from .request       import standard_request_handler, to_device, get_request_handler_methods
@@ -665,8 +666,10 @@ class USBBaseDevice(USBDescribable, USBRequestHandler):
         else:
             return self.strings[index]
 
-
-    def handle_generic_get_descriptor_request(self, request: USBControlRequest):
+    @staticmethod
+    def handle_generic_get_descriptor_request(
+            descriptor_container:Union['USBDevice', USBInterface],
+            request: USBControlRequest):
         """ Handle GET_DESCRIPTOR requests; per USB2 [9.4.3] """
 
         logging.debug(f"received GET_DESCRIPTOR request {request}")
@@ -676,7 +679,7 @@ class USBBaseDevice(USBDescribable, USBRequestHandler):
         descriptor_index = request.value_low
 
         # Try to find the descriptor associate with the request.
-        response = self.descriptors.get(descriptor_type, None)
+        response = descriptor_container.descriptors.get(descriptor_type, None)
 
         # If we have a callable, we need to evaluate it to figure
         # out what the actual descriptor should be.
@@ -763,7 +766,7 @@ class USBDevice(USBBaseDevice):
         """ Handle GET_DESCRIPTOR requests; per USB2 [9.4.3] """
 
         # Defer to our generic get_descriptor handler.
-        self.handle_generic_get_descriptor_request(request)
+        self.handle_generic_get_descriptor_request(self, request)
 
 
 

--- a/facedancer/future/endpoint.py
+++ b/facedancer/future/endpoint.py
@@ -157,7 +157,7 @@ class USBEndpoint(USBDescribable, AutoInstantiable, USBRequestHandler):
 
     def matches_identifier(self, other:int) -> bool:
         # Use only the MSB and the lower nibble; per the USB specification.
-        masked_other = 0b10001111
+        masked_other = other & 0b10001111
         return self.get_identifier() == masked_other
 
 

--- a/facedancer/future/interface.py
+++ b/facedancer/future/interface.py
@@ -181,9 +181,8 @@ class USBInterface(USBDescribable, AutoInstantiable, USBRequestHandler):
         """ Handle GET_DESCRIPTOR requests; per USB2 [9.4.3] """
         logging.debug("Handling GET_DESCRIPTOR on endpoint.")
 
-        # This is the same as the USBDevice get descriptor request;
-        # delegate to its unbound method to avoid duplication.
-        device.USBDevice.handle_generic_get_descriptor_request(self, request)
+        # This is the same as the USBDevice get descriptor request => avoid duplication.
+        self.get_device().handle_generic_get_descriptor_request(self, request)
 
 
     # Table 9-12 of USB 2.0 spec (pdf page 296)

--- a/facedancer/future/request.py
+++ b/facedancer/future/request.py
@@ -170,7 +170,7 @@ def to_any_endpoint(func):
 
 def to_this_interface(func):
     """ Decorator; refines a handler so it's only called on requests targeting this interface. """
-    return _wrap_with_field_matcher(func, 'recipient', USBRequestRecipient.INTERFACE)
+    return _wrap_with_field_matcher(func, 'recipient', USBRequestRecipient.INTERFACE, match_index=True)
 
 def to_any_interface(func):
     """ Decorator; refines a handler so it's only called on requests with an interface recipient. """


### PR DESCRIPTION
Requests that are Endpoint/Interface specific did not call the handler method within the corresponding USBEndpoint/USBInterface object. Usually these handler methods are decorated by ``@to_this_endpoint`` or ``@to_this_interface``. But both decorators did not work as expected:
 * to_this_endpoint worked only on IN endpoint with address 15
 * to_this_interface delegated *all* requests to the first interface implementing the corresponding descriptor. \
This is for example problematic when implementing a composite usb device consisting of i.e. two independent HID devices (both providing a REPORT descriptor). The GetDescriptor command for retrieving the REPORT descriptor will always return the REPORT descriptor of the first interface (no matter what index parameter is passed).