### PR TITLE
Update Python requirements

### DIFF
--- a/facedancer/backends/goodfet.py
+++ b/facedancer/backends/goodfet.py
@@ -21,7 +21,7 @@ class GoodfetMaxUSBApp(MAXUSBApp):
         Determines if the current environment seems appropriate
         for using the GoodFET::MaxUSB backend.
         """
-        # Check: if we have a backend name other than greatfet,
+        # Check: if we have a backend name other than goodfet,
         # the user is trying to use something else. Abort!
         if backend_name and backend_name != "goodfet":
             return False

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
 
     license='BSD',
     tests_require=[''],
-    install_requires=['pyusb'],
+    install_requires=['pyusb', 'pyserial'],
     description='Python library for emulating USB devices',
     long_description=read('README.md'),
     packages=find_packages(),


### PR DESCRIPTION
I had been getting a device not found error when using my Facedander21. It turned out that I wasn't importing `serial`, but that specific error wasn't getting propagated back and instead turned up as "device not found".

Also fixed a comment noticed while tracking this down.