### PR TITLE
Packaging: migrate from setup.py to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "facedancer"
 dynamic = ["version"]
 authors = [
-    {name = "Kate Temkin", email = "kate@ktemkin.com"},
+    {name = "Great Scott Gadgets", email = "dev@greatscottgadgets.com"},
 ]
 license = { text = "BSD" }
 description = "Python library for emulating USB devices"


### PR DESCRIPTION
This PR contains:

1. Metadata updates for authors 
2. A shim for `setup.py` as CI still relies on a `python setup.py` flow