### PR TITLE
Added setup.py and Requirements.txt, modified README.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@ the original GoodFET-based FaceDancer, this repository provides a python module
 that provides expanded FaceDancer support-- including support for multiple boards 
 and some pretty significant new features.
 
+## Installation
+Install this package via the following commands:
+```
+pip install -r Requirements.txt
+pip install .
+```
+After that you can import facedancer as a module:
+```
+$ python
+>>> import facedancer
+```
+
 ## Where are my scripts?
 
 In preparation for the 3.0 release of FaceDancer, scripts in the "old" style have

--- a/Requirements.txt
+++ b/Requirements.txt
@@ -1,0 +1,2 @@
+pyusb
+prompt-toolkit

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup, find_packages
+
+setup(
+   name='facedancer',
+   version='2.9',
+   description='modern FaceDancer core for multiple devices-- including GreatFET ',
+   author='greatscottgadgets',
+   author_email='',
+   #packages=['facedancer'],  #same as name
+   packages=find_packages(),
+   install_requires=['pyusb', 'prompt-toolkit'], #external packages as dependencies
+)
+


### PR DESCRIPTION
The repository lagged a way to install the facedancer package. 
Therefore, I made the following additions:
* added `setup.py`
* added `Requirements.txt`
* made changes to the `README.txt`

Now the package and all its requirements can be installed as follows:
```
pip install -r Requirements.txt
pip install .
```