### PR TITLE
Mistyped endpoint direction in the device template

### DIFF
--- a/examples/template.py
+++ b/examples/template.py
@@ -175,7 +175,7 @@ class TemplateDevice(USBDevice):
                 # We'll use a more typical set of properties for our OUT endpoint.
                 #
                 number               : int                    = 1
-                direction            : USBDirection           = USBDirection.IN
+                direction            : USBDirection           = USBDirection.OUT
 
 
                 #


### PR DESCRIPTION
Hello neighbors,
I've just started digging a bit deeper into FaceDancer and I have a really really tiny contribution to the device template for you.
I've noticed that the ```USBDirection``` is set to ```IN``` twice, that is for the ```TemplateOutEndpoint``` class as well.
I guess this is a typo, right?

Cheers 😊