### PR TITLE
New Hydradancer backend for Facedancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,17 @@ export BACKEND=greatfet
  * The CCCamp 2015 rad1o badge with GreatFET l0adable (```BACKEND=greatfet```)
  * All GoodFET-based Facedancers, including the common Facedancer21 (```BACKEND=goodfet```)
  * RPi + Max3241 Raspdancer boards (```BACKEND=raspdancer```)
+ * Hydradancer and HydraUSB3 boards (```BACKEND=hydradancer```)
 
 Note that hardware restrictions prevent the MAX3420/MAX3421 boards from emulating
 more complex devices -- there's limitation on the number/type of endpoints that can be
 set up. The LPC4330 boards -- such as the GreatFET -- have fewer limitations.
 
 For a similar reason, the MAX3420/MAX3421 boards (`BACKEND=goodfet` or `BACKEND=raspdancer`)
-currently cannot be used as USBProxy-nv MITM devices. All modern boards (`BACKEND=greatfet`)
+currently cannot be used as USBProxy-nv MITM devices. All modern boards (`BACKEND=greatfet`, `BACKEND=hydradancer`)
 should be fully functional.
+
+Note that the Hydradancer and HydraUSB3 boards (`BACKEND=greatfet`) do not currently support host-mode.
 
 ## What boards could be supported soon?
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ export BACKEND=greatfet
  * The CCCamp 2015 rad1o badge with GreatFET l0adable (```BACKEND=greatfet```)
  * All GoodFET-based Facedancers, including the common Facedancer21 (```BACKEND=goodfet```)
  * RPi + Max3241 Raspdancer boards (```BACKEND=raspdancer```)
- * Hydradancer and HydraUSB3 boards (```BACKEND=hydradancer```)
+ * HydraDancer and HydraUSB3 boards (```BACKEND=hydradancer```)
 
 Note that hardware restrictions prevent the MAX3420/MAX3421 boards from emulating
 more complex devices -- there's limitation on the number/type of endpoints that can be
@@ -109,7 +109,8 @@ For a similar reason, the MAX3420/MAX3421 boards (`BACKEND=goodfet` or `BACKEND=
 currently cannot be used as USBProxy-nv MITM devices. All modern boards (`BACKEND=greatfet`, `BACKEND=hydradancer`)
 should be fully functional.
 
-Note that the Hydradancer and HydraUSB3 boards (`BACKEND=greatfet`) do not currently support host-mode.
+Note that the HydraDancer and HydraUSB3 boards (`BACKEND=hydradancer`) do not currently support host-mode.
+Note actual FaceDancer 3.0 does not work on Windows(some issues in pyusb...) and only GNU/Linux
 
 ## What boards could be supported soon?
 

--- a/facedancer/backends/__init__.py
+++ b/facedancer/backends/__init__.py
@@ -6,4 +6,5 @@ __all__ = [
     "greathost",
     "libusbhost",
     "moondancer",
+    "hydradancer"
 ]

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -317,7 +317,11 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
 
         for ep_num, ep in self.ep_in.items():
             if self.api.in_buffer_empty(ep_num) and self.api.nak_on_endpoint(ep_num):
-                if len(self.ep_transfer_queue[ep_num]) > 0:
+                if len(self.ep_transfer_queue[ep_num]) == 0:
+                    self.connected_device.handle_nak(ep_num)
+                
+                # The queue might not be empty anymore, check immediately
+                if len(self.ep_transfer_queue[ep_num]) != 0:
                     max_packet_size = ep.max_packet_size
                     packet = self.ep_transfer_queue[ep_num][0][0:max_packet_size]
                     self.ep_transfer_queue[ep_num][0] = self.ep_transfer_queue[ep_num][0][len(packet):]
@@ -326,8 +330,6 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
 
                     if len(self.ep_transfer_queue[ep_num][0]) == 0:
                         self.ep_transfer_queue[ep_num].pop(0)
-                else:
-                    self.connected_device.handle_nak(ep_num)
 
     def handle_control_request(self):
         if not self.api.control_buffer_available():

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -600,8 +600,9 @@ class HydradancerBoard():
 
     def do_bus_reset(self):
         """
-        Set the speed of the USB2 device. Speed is physically determined by the host,
-        so the emulation board must be configured.
+        At this point, the USB2 controller has already set its address to 0 and reset its endpoints.
+        Facedancer has then been warned about the reset to handle its side of the reset.
+        Finally, we tell the boards to reset their internal state to complete the reset.
         """
         try:
             self.reinit(keep_ep0=True)

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -90,8 +90,6 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
         self.ep_in = {}
         self.ep_out = {}
 
-        self.legacy_mode = False  # legacy_mode is used for legacy_applets
-
         self.api = HydradancerBoard()
         self.verbose = verbose
         self.api.wait_board_ready()
@@ -124,7 +122,6 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
 
         self.connected_device = usb_device
 
-        # self.legacy_mode = isinstance(self.connected_device, USBDevice) # How can we detect this ? there are still a lot of legacy apps
         self.max_ep0_packet_size = max_packet_size_ep0
 
     def disconnect(self):
@@ -300,23 +297,6 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
                 else:
                     self.connected_device.handle_nak(ep_num)
 
-    # def handle_data_endpoints_legacy(self):
-    #     """
-    #     Handle IN or OUT requests on non-control endpoints for the legacy_applets
-    #     """
-    #     # process ep OUT firsts, transfer is dictated by the host, if there is data available on an ep OUT,
-    #     # it should be processed before setting new IN data
-    #     for ep_num, ep in self.ep_out.items():
-    #         if self.api.OUT_buffer_available(ep_num):
-    #             data = self.api.read(ep_num)
-    #             if data is not None:
-    #                 self.connected_device.handle_data_available(
-    #                     ep_num, data.tobytes())
-
-    #     for ep_num, ep in self.ep_in.items():
-    #         if self.api.IN_buffer_empty(ep_num):
-    #             self.connected_device.handle_nak(ep)
-
     def handle_control_request(self):
         if not self.api.CONTROL_buffer_available():
             return
@@ -366,10 +346,7 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
 
         self.handle_control_request()
 
-        if not self.legacy_mode:
-            self.handle_data_endpoints()
-            # else:  # support for old USBDevice
-            #     self.handle_data_endpoints_legacy()
+        self.handle_data_endpoints()
 
         if events is not None:
             for event in events:

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -115,6 +115,7 @@ class HydradancerHostApp(FacedancerApp):
     def disconnect(self):
         """ Disconnects the Hydradancer from its target host. """
         logging.info("disconnect")
+        self.configuration = None
         self.api.disconnect()
 
     def send_on_endpoint(self, ep_num, data, blocking=False):
@@ -198,7 +199,12 @@ class HydradancerHostApp(FacedancerApp):
 
         configuration: The configuration applied by the SET_CONFIG request.
         """
-        logging.info("configured")
+
+        if configuration is None:
+            self.configuration = None
+            self.api.configured = False
+            logging.debug("unconfigured")
+            return
 
         self.api.reinit(keep_ep0=True)
         endpoint_numbers = []
@@ -217,6 +223,7 @@ class HydradancerHostApp(FacedancerApp):
 
         self.api.configure(endpoint_numbers)
         self.configuration = configuration
+        logging.debug("configured")
 
     def ack_status_stage(self, direction=HOST_TO_DEVICE, endpoint_number=0, blocking=False):
         """

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -321,7 +321,7 @@ class HydradancerHostApp(FacedancerApp):
 
         # handle status stage of IN transfer
         elif len(data) == 0:
-            logging.debug("Received ACK for IN Ctrl req")
+            logging.debug("Received ACK for IN Ctrl req")            
 
     def service_irqs(self):
         """
@@ -678,7 +678,7 @@ class HydradancerBoard():
                 self.hydradancer_status["ep_out_status"] &= ~(0x01 << ep_num)
                 return read
             return None
-        except (usb.core.USBTimeoutError, usb.core.USBError):
+        except (usb.core.USBTimeoutError, usb.core.USBError) as e:
             logging.error(f"could not read data from ep {ep_num}")
             return None
 
@@ -750,7 +750,9 @@ class HydradancerBoard():
 
     def bus_reset_pending(self):
         """
-        Returns True if the IN buffer for the control endpoint is ready for priming. 
-        Note that currently all control requests (whatever the endpoint num it arrived with) will end up here.
+        Returns True if a bus reset should be performed.
+        1. Bus reset is received on the board : the addresss is set to 0.
+        2. The bit in other_events is set, so that the Facedancer backend can perform its reset.
+        3. The Facedancer backend sends a control message to the board so that it finishes the bus reset.
         """
         return self.hydradancer_status["other_events"] & self.HYDRADANCER_STATUS_BUS_RESET

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -290,7 +290,16 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
                 if event is None:
                     continue
                 if event.event_type == HydradancerEvent.EVENT_BUS_RESET:
-                    self.reset()
+                    self.handle_bus_reset()
+
+    def handle_bus_reset(self):
+        """
+        Triggers Hydradancer to perform its side of a bus reset.
+        """
+        if self.connected_device:
+            self.connected_device.handle_bus_reset()
+        else:
+            self.reset()
 
     def handle_data_endpoints(self):
         """

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -369,8 +369,9 @@ class HydradancerBoard():
     endpoints_mapping = {}  # emulated endpoint -> control board endpoint
     reverse_endpoints_mapping = {}  # control_board_endpoint -> emulated_endpoint
 
-    EP_POLL_NUMBER = 6
-    EP_LOG_NUMBER = 7
+    EP_POLL_NUMBER = 1
+
+    SUPPORTED_EP_NUM = [0, 1, 2, 3, 4, 5, 6, 7]
 
     # True when SET_CONFIGURATION has been received and the Hydradancer boards are configured
     configured = False
@@ -423,8 +424,7 @@ class HydradancerBoard():
             custom_match=lambda e:
             usb.util.endpoint_direction(e.bEndpointAddress) ==
             usb.util.ENDPOINT_IN and usb.util.endpoint_address(e.bEndpointAddress) !=
-            self.EP_POLL_NUMBER and usb.util.endpoint_address(e.bEndpointAddress) !=
-            self.EP_LOG_NUMBER))
+            self.EP_POLL_NUMBER))
 
         self.ep_in = {usb.util.endpoint_address(
             e.bEndpointAddress): e for e in self.ep_in}
@@ -435,8 +435,7 @@ class HydradancerBoard():
             custom_match=lambda e:
             usb.util.endpoint_direction(e.bEndpointAddress) ==
             usb.util.ENDPOINT_OUT and usb.util.endpoint_address(e.bEndpointAddress) !=
-            self.EP_POLL_NUMBER and usb.util.endpoint_address(e.bEndpointAddress) !=
-            self.EP_LOG_NUMBER))
+            self.EP_POLL_NUMBER))
 
         self.ep_out = {usb.util.endpoint_address(
             ep.bEndpointAddress): ep for ep in self.ep_out}
@@ -546,6 +545,9 @@ class HydradancerBoard():
         """
         Maps emulated endpoints (endpoints facing the target) to Facedancer's host endpoints (control board endpoints)
         """
+        if ep_num not in self.SUPPORTED_EP_NUM:
+            raise HydradancerBoardFatalError(
+                f"Endpoint number {ep_num} not supported, supported numbers : {self.SUPPORTED_EP_NUM}")
         self.endpoints_mapping[ep_num] = self.endpoints_pool.pop()
         self.reverse_endpoints_mapping[self.endpoints_mapping[ep_num]] = ep_num
         try:

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -471,7 +471,7 @@ class HydradancerBoard():
             raise HydradancerBoardFatalError(
                 f"Could not get handle on Hydradancer events endpoint (EP {self.EP_POLL_NUMBER})")
 
-        self.endpoints_pool = list(self.ep_in.keys())
+        self.endpoints_pool = set(self.ep_in.keys())
 
         # wait until the board is ready, for instance if a disconnect was previously issued
         self.wait_board_ready()
@@ -498,7 +498,6 @@ class HydradancerBoard():
             usb.util.dispose_resources(self.device)
 
             # Reset state just in case
-            self.endpoints_pool = list(self.ep_in.keys())
             self.hydradancer_status["ep_in_status"] = 0x00
             self.hydradancer_status["ep_out_status"] = 0x00
             self.hydradancer_status["ep_in_nak"] = 0x00
@@ -564,7 +563,7 @@ class HydradancerBoard():
             raise HydradancerBoardFatalError(
                 f"All endpoints are already in use")
             
-        self.endpoints_mapping[ep_num] = self.endpoints_pool.pop()
+        self.endpoints_mapping[ep_num] = list(self.endpoints_pool - set(self.endpoints_mapping.values()))[0]
         self.reverse_endpoints_mapping[self.endpoints_mapping[ep_num]] = ep_num
         try:
             self.device.ctrl_transfer(CTRL_TYPE_VENDOR | CTRL_RECIPIENT_DEVICE | CTRL_OUT,

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -305,6 +305,7 @@ class HydradancerHostApp(FacedancerApp):
                 self.connected_device.handle_request(
                     self.pending_control_out_request)
                 self.pending_control_out_request = None
+                # self.ack_status_stage(direction=self.HOST_TO_DEVICE) Not handling ZLP because right now, parts of Facedancer are handling it (SET_INTERFACE for instance)
         elif len(data) > 0:
             request = self.connected_device.create_request(data)
             is_out = request.get_direction() == self.HOST_TO_DEVICE

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -214,7 +214,7 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
         """
         if endpoint_number != 0 and not blocking:
             logging.debug(f"Storing {len(data)} on ep {endpoint_number} for later")
-            self.ep_transfer_queue[endpoint_number].append([data, len(data)])
+            self.ep_transfer_queue[endpoint_number].append(data)
             return
 
         backup_len = len(data)
@@ -310,12 +310,12 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
             if self.api.in_buffer_empty(ep_num) and self.api.nak_on_endpoint(ep_num):
                 if len(self.ep_transfer_queue[ep_num]) > 0:
                     max_packet_size = ep.max_packet_size
-                    packet = self.ep_transfer_queue[ep_num][0][0][0:max_packet_size]
-                    self.ep_transfer_queue[ep_num][0][0] = self.ep_transfer_queue[ep_num][0][0][len(packet):]
+                    packet = self.ep_transfer_queue[ep_num][0][0:max_packet_size]
+                    self.ep_transfer_queue[ep_num][0] = self.ep_transfer_queue[ep_num][0][len(packet):]
 
                     self.api.send(ep_num, packet, blocking = True)
 
-                    if len(self.ep_transfer_queue[ep_num][0][0]) == 0:
+                    if len(self.ep_transfer_queue[ep_num][0]) == 0:
                         self.ep_transfer_queue[ep_num].pop(0)
                 else:
                     self.connected_device.handle_nak(ep_num)

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -1,0 +1,678 @@
+"""
+Backend for HydraUSB3.
+
+Supports 4 high-speed endpoints, with addresses between 1 and 7.
+"""
+
+import sys
+import logging
+import usb
+from usb.util import CTRL_TYPE_VENDOR, CTRL_RECIPIENT_DEVICE, CTRL_IN, CTRL_OUT, ENDPOINT_IN
+import time
+from array import array
+
+from ..core import FacedancerApp
+from ..USBDevice import USBDevice
+
+
+class HydradancerHostApp(FacedancerApp):
+    """
+    Backend for the HydraUSB3 boards.
+
+    It supports USB2 High-speed, the speed can be set with the attribute "usb2_speed" of the device class.
+    If this attribute is not present, it will default to full-speed (the speed currently assumed by the examples).
+    """
+    app_name = "Hydradancer Host"
+
+    # USB directions
+    HOST_TO_DEVICE = 0
+    DEVICE_TO_HOST = 1
+
+    # USB speeds
+    USB2_LS = 0  # low-speed
+    USB2_FS = 1  # full-speed
+    USB2_HS = 2  # high-speed
+
+    usb2_speed = USB2_FS  # default to full-speed
+
+    configuration = None
+    pending_control_out_request = None
+    connected_device = None
+    max_ep0_packet_size = None
+
+    legacy_mode = False  # legacy_mode is used for legacy_applets
+
+    @classmethod
+    def appropriate_for_environment(cls, backend_name):
+        """
+        Determines if the current environment seems appropriate
+        for using the libusb backend.
+        """
+
+        logging.info("this is hydradancer hi")
+        # Open a connection to the target device...
+        device = usb.core.find(idVendor=0x16c0, idProduct=0x27d8)
+
+        if device is not None and backend_name == "hydradancer":
+            return True
+
+        return False
+
+    def __init__(self, verbose=0, quirks=[], index=0, **kwargs):
+        """
+        Creates a new hydradancer backend for communicating with a target device.
+        """
+
+        super().__init__(self)
+        self.api = HydradancerBoard()
+        self.verbose = verbose
+        self.api.init()
+        self.api.wait_board_ready()
+
+    def init_commands(self):
+        """
+        API compatibility function;
+        """
+
+    def get_version(self):
+        raise NotImplementedError()
+
+    def connect(self, usb_device, max_ep0_packet_size=64):
+        """
+        Prepares Hydradancer to connect to the target host and emulate
+        a given device.
+
+        usb_device: The USBDevice object that represents the device to be
+            emulated.
+        """
+        self.api.set_endpoint_mapping(0)
+
+        if hasattr(usb_device, 'usb2_speed'):
+            self.usb2_speed = usb_device.usb2_speed
+
+        if self.usb2_speed == self.USB2_LS:
+            logging.info("Setting speed to low-speed")
+        elif self.usb2_speed == self.USB2_FS:
+            logging.info("Setting speed to full-speed")
+        elif self.usb2_speed == self.USB2_HS:
+            logging.info("Setting speed to high-speed")
+        else:
+            logging.info("Setting speed to full-speed")
+
+        self.api.set_usb2_speed(self.usb2_speed)
+        logging.info("connect ...")
+
+        self.api.connect()
+
+        self.connected_device = usb_device
+
+        self.legacy_mode = isinstance(self.connected_device, USBDevice)
+        self.max_ep0_packet_size = max_ep0_packet_size
+
+    def disconnect(self):
+        """ Disconnects the Hydradancer from its target host. """
+        logging.info("disconnect")
+        self.api.disconnect()
+
+    def send_on_endpoint(self, ep_num, data, blocking=False):
+        """
+        Sends a collection of USB data on a given endpoint.
+
+        ep_num: The number of the IN endpoint on which data should be sent.
+        data: The data to be sent.
+        blocking: If true, this function will wait for the transfer to complete.
+        """
+        logging.debug(f"EP{ep_num}/IN: -> size {len(data)} {bytes(data)}")
+        self.api.send(ep_num, data, blocking)
+
+    def read_from_endpoint(self, ep_num):
+        """
+        Reads a block of data from the given endpoint.
+
+        ep_num: The number of the OUT endpoint on which data is to be rx'd.
+        """
+        return self.api.read(ep_num, blocking=True)
+
+    def stall_endpoint(self, ep_num, direction=0):
+        """
+        Stalls the provided endpoint, as defined in the USB spec.
+
+        ep_num: The number of the endpoint to be stalled.
+        """
+
+        in_vs_out = "IN" if direction else "OUT"
+        logging.info(f"Stalling EP {ep_num} {in_vs_out}")
+
+        self.api.stall_endpoint(ep_num, direction)
+
+    def stall_ep0(self):
+        """
+        Convenience function that stalls the control endpoint zero.
+        """
+        logging.info("stall_ep0")
+        self.stall_endpoint(0)
+
+    def set_address(self, address, defer=False):
+        """
+        Sets the device address of the Hydradancer. Usually only used during
+        initial configuration.
+
+        address: The address that the Hydradancer should assume.
+        defer: True if the set_address request should wait for an active transaction to finish.
+        """
+        logging.info("set address")
+        self.api.set_address(address, defer)
+
+    def reset(self):
+        """
+        Triggers the Hydradancer to handle its side of a bus reset.
+        """
+        logging.warning("reset, not implemented")
+
+    def configured(self, configuration):
+        """
+        Callback that's issued when a USBDevice is configured, e.g. by the
+        SET_CONFIGURATION request. Allows us to apply the new configuration.
+
+        configuration: The configuration applied by the SET_CONFIG request.
+        """
+        logging.info("configured")
+
+        endpoint_numbers = []
+
+        if not self.legacy_mode:
+            for endpoint in configuration.interfaces[0].endpoints:
+                ep_num = usb.util.endpoint_address(endpoint)
+                if ep_num not in endpoint_numbers:
+                    endpoint_numbers.append(ep_num)
+
+        else:
+            for endpoint in configuration.get_interfaces()[0].endpoints:
+                ep_num = endpoint.number
+                if ep_num not in endpoint_numbers:
+                    endpoint_numbers.append(ep_num)
+
+        self.api.configure(endpoint_numbers)
+        self.configuration = configuration
+
+    def ack_status_stage(self, direction=HOST_TO_DEVICE, endpoint_number=0, blocking=False):
+        """
+            Handles the status stage of a correctly completed control request,
+            by priming the appropriate endpoint to handle the status phase.
+
+            direction: Determines if we're ACK'ing an IN or OUT vendor request.
+                (This should match the direction of the DATA stage.)
+            endpoint_number: The endpoint number on which the control request
+                occurred.
+            blocking: True if we should wait for the ACK to be fully issued
+                before returning.
+        """
+        if direction == self.HOST_TO_DEVICE:
+            # If this was an OUT request, we'll prime the output buffer to
+            # respond with the ZLP expected during the status stage.
+            self.send_on_endpoint(endpoint_number, data=[], blocking=blocking)
+
+        else:
+            # If this was an IN request, we'll need to set up a transfer descriptor
+            # so the status phase can operate correctly. This effectively reads the
+            # zero length packet from the STATUS phase.
+            self.read_from_endpoint(endpoint_number)
+
+    def handle_data_endpoints(self):
+        """
+        Handle IN or OUT requests on non-control endpoints.
+        """
+
+        # process ep OUT firsts, transfer is dictated by the host, if there is data available on an ep OUT,
+        # it should be processed before setting new IN data
+        for endp in self.configuration.interfaces[0].endpoints:
+            ep_dir_in = usb.util.endpoint_direction(endp) == ENDPOINT_IN
+            ep_num = usb.util.endpoint_address(endp)
+
+            if not ep_dir_in and self.api.OUT_buffer_available(ep_num):
+                data = self.api.read(ep_num)
+                if data is not None:
+                    self.connected_device.handle_data_available(
+                        ep_num, data.tobytes())
+
+        for endp in self.configuration.interfaces[0].endpoints:
+            ep_dir_in = usb.util.endpoint_direction(endp) == ENDPOINT_IN
+            ep_num = usb.util.endpoint_address(endp)
+
+            if ep_dir_in and self.api.IN_buffer_empty(ep_num):
+                ep = self.configuration.get_endpoint(ep_num, ep_dir_in)
+                if ep is not None:
+                    self.connected_device.handle_data_requested(ep)
+
+    def handle_data_endpoints_legacy(self):
+        """
+        Handle IN or OUT requests on non-control endpoints for the legacy_applets
+        """
+        # process ep OUT firsts, transfer is dictated by the host, if there is data available on an ep OUT,
+        # it should be processed before setting new IN data
+        for endp in self.configuration.get_interfaces()[0].endpoints:
+            ep_dir_in = endp.direction == 1
+            ep_num = endp.number
+
+            if not ep_dir_in and self.api.OUT_buffer_available(ep_num):
+                data = self.api.read(ep_num)
+                if data is not None:
+                    self.connected_device.handle_data_available(
+                        ep_num, data.tobytes())
+
+        for endp in self.configuration.get_interfaces()[0].endpoints:
+            ep_dir_in = endp.direction == 1
+            ep_num = endp.number
+            if ep_dir_in and self.api.IN_buffer_empty(ep_num):
+                self.connected_device.handle_buffer_available(ep_num)
+
+    def handle_control_request(self):
+        if not self.api.CONTROL_buffer_available():
+            return
+
+        data = self.api.read(0)
+        if data is None:
+            return
+
+        logging.debug(
+            f"CONTROL EP/OUT: -> size {len(data)} {bytes(data)}")
+
+        #  inspired from moondancer and greatdancer backends
+        if self.pending_control_out_request is not None:
+            self.pending_control_out_request.data.extend(data)
+            all_data_received = len(
+                self.pending_control_out_request.data) == self.pending_control_out_request.length
+            is_short_packet = len(data) < self.max_ep0_packet_size
+
+            if all_data_received or is_short_packet:
+                self.connected_device.handle_request(request)
+                self.pending_control_out_request = None
+        elif len(data) > 0:
+            request = self.connected_device.create_request(data)
+            is_out = request.get_direction() == self.HOST_TO_DEVICE
+            has_data = (request.length > 0)
+
+            if is_out and has_data:
+                logging.debug("queuing Control OUT req, waiting for more data")
+                self.pending_control_out_request = request
+                return
+
+            self.connected_device.handle_request(request)
+
+        # handle status stage of IN transfer
+        elif len(data) == 0:
+            logging.debug("Received ACK for IN Ctrl req")
+
+    def service_irqs(self):
+        """
+        Core routine of the Facedancer execution/event loop. Continuously monitors the
+        Hydradancers's execution status, and reacts as events occur.
+        """
+
+        self.api.fetch_events()
+
+        self.handle_control_request()
+
+        if self.configuration is not None:
+            if not self.legacy_mode:
+                self.handle_data_endpoints()
+            else:  # support for old USBDevice
+                self.handle_data_endpoints_legacy()
+
+
+class HydradancerBoardFatalError(Exception):
+    pass
+
+
+class HydradancerBoard():
+    """
+    Handles the communication with the Hydradancer control board and manages the events it sends.
+    """
+
+    MAX_PACKET_SIZE = 512
+
+    # USB Vendor Requests codes
+    ENABLE_USB_CONNECTION_REQUEST_CODE = 50
+    SET_ADDRESS_REQUEST_CODE = 51
+    GET_EP_STATUS = 52
+    SET_ENDPOINT_MAPPING = 53
+    DISABLE_USB = 54
+    SET_SPEED = 55
+    SET_EP_RESPONSE = 56
+    CHECK_HYDRADANCER_READY = 57
+
+    # USB speeds
+    USB2_LS = 0
+    USB2_FS = 1
+    USB2_HS = 2
+
+    # Endpoint states on the emulation board
+    ENDP_STATE_ACK = 0x00
+    ENDP_STATE_NAK = 0x02
+    ENDP_STATE_STALL = 0x03
+
+    # Endpoints available on the control board for mapping (to the emulated device endpoints)
+    endpoints_pool = None
+    endpoints_mapping = {}  # emulated endpoint -> control board endpoint
+    reverse_endpoints_mapping = {}  # control_board_endpoint -> emulated_endpoint
+
+    EP_POLL_NUMBER = 6
+    EP_LOG_NUMBER = 7
+
+    # True when SET_CONFIGURATION has been received and the Hydradancer boards are configured
+    configured = False
+
+    # 0x00ff (IN status mask, 1 = emulated ep ready for priming), 0xff00 (OUT mask, data received on emulated ep)
+    ep_status = 0x0000
+    new_ep_status = array('b', [0, 0])
+
+    timeout_ms_poll = 1
+
+    # USB endpoints direction
+    HOST_TO_DEVICE = 0
+    DEVICE_TO_HOST = 1
+
+    def init(self):
+        """
+        Get handles on the USB control board, and wait for Hydradancer to be ready
+        """
+
+        # Open a connection to the target device...
+        self.device = usb.core.find(idVendor=0x16c0, idProduct=0x27d8)
+
+        if self.device is None:
+            raise HydradancerBoardFatalError("Hydradancer board not found")
+
+        if self.device.speed != usb.util.SPEED_SUPER:
+            raise HydradancerBoardFatalError(
+                "Hydradancer not detected as USB3 Superspeed")
+
+        cfg = self.device.get_active_configuration()
+        intf = cfg[(0, 0)]
+
+        # Detach the device from any kernel driver
+        for intf in cfg:
+            if self.device.is_kernel_driver_active(intf.bInterfaceNumber):
+                try:
+                    self.device.detach_kernel_driver(intf.bInterfaceNumber)
+                except usb.core.USBError as e:
+                    sys.exit("Could not detach kernel driver from interface({0}): {1}".format(
+                        intf.bInterfaceNumber, str(e)))
+
+        # store the different endpoints handles we need
+        self.ep_in = list(usb.util.find_descriptor(
+            intf,
+            find_all=True,
+            custom_match=lambda e:
+            usb.util.endpoint_direction(e.bEndpointAddress) ==
+            usb.util.ENDPOINT_IN and usb.util.endpoint_address(e.bEndpointAddress) !=
+            self.EP_POLL_NUMBER and usb.util.endpoint_address(e.bEndpointAddress) !=
+            self.EP_LOG_NUMBER))
+
+        self.ep_in = {usb.util.endpoint_address(
+            e.bEndpointAddress): e for e in self.ep_in}
+
+        self.ep_out = list(usb.util.find_descriptor(
+            intf,
+            find_all=True,
+            custom_match=lambda e:
+            usb.util.endpoint_direction(e.bEndpointAddress) ==
+            usb.util.ENDPOINT_OUT and usb.util.endpoint_address(e.bEndpointAddress) !=
+            self.EP_POLL_NUMBER and usb.util.endpoint_address(e.bEndpointAddress) !=
+            self.EP_LOG_NUMBER))
+
+        self.ep_out = {usb.util.endpoint_address(
+            ep.bEndpointAddress): ep for ep in self.ep_out}
+
+        # the endpoint on which status information is received
+        self.ep_poll = usb.util.find_descriptor(
+            intf,
+            custom_match=lambda e:
+            usb.util.endpoint_direction(e.bEndpointAddress) ==
+            usb.util.ENDPOINT_IN and usb.util.endpoint_address(e.bEndpointAddress) ==
+            self.EP_POLL_NUMBER)
+
+        if len(self.ep_in.keys()) == 0 and len(self.ep_out.keys()) == 0:
+            logging.info("Dumping device configuration \r\n" + str(cfg))
+            raise HydradancerBoardFatalError(
+                "Could not fetch Hydradancer IN and OUT endpoints list")
+        if len(self.ep_in.keys()) == 0:
+            logging.info("Dumping device configuration \r\n" + str(cfg))
+            raise HydradancerBoardFatalError(
+                "Could not fetch Hydradancer IN endpoints list")
+        if len(self.ep_out.keys()) == 0:
+            logging.info("Dumping device configuration \r\n" + str(cfg))
+            raise HydradancerBoardFatalError(
+                "Could not fetch Hydradancer OUT endpoints list")
+        if self.ep_out.keys() != self.ep_in.keys():
+            logging.info("Dumping device configuration \r\n" + str(cfg))
+            raise HydradancerBoardFatalError(
+                f"Hydradancer IN/OUT endpoints pair incomplete \r\nep_in {self.ep_in} \r\nep_out {self.ep_out}")
+        if self.ep_poll is None:
+            logging.info("Dumping device configuration \r\n" + str(cfg))
+            raise HydradancerBoardFatalError(
+                f"Could not get handle on Hydradancer events endpoint (EP {self.EP_POLL_NUMBER})")
+
+        self.endpoints_pool = list(self.ep_in.keys())
+
+        # wait until the board is ready, for instance if a disconnect was previously issued
+        self.wait_board_ready()
+
+    def connect(self):
+        """
+        Enable the USB2 connection on the emulation board
+        """
+        try:
+            self.device.ctrl_transfer(
+                CTRL_TYPE_VENDOR | CTRL_RECIPIENT_DEVICE | CTRL_OUT, self.ENABLE_USB_CONNECTION_REQUEST_CODE)
+        except (usb.core.USBTimeoutError, usb.core.USBError) as exception:
+            logging.error(exception)
+            raise HydradancerBoardFatalError("Error, unable to connect")
+
+    def disconnect(self):
+        """
+        Disable the USB2 connection on the emulation board,
+        and reset internal states on both control and emulation boards.
+        """
+        try:
+            self.device.ctrl_transfer(
+                CTRL_TYPE_VENDOR | CTRL_RECIPIENT_DEVICE | CTRL_OUT, self.DISABLE_USB)
+            usb.util.dispose_resources(self.device)
+        except (usb.core.USBTimeoutError, usb.core.USBError) as exception:
+            logging.error(exception)
+            raise HydradancerBoardFatalError("Error, unable to disconnect")
+
+    def wait_board_ready(self):
+        """
+        Wait until the Hydradancer boards are ready, try to disconnect at some point to reset the internal states,
+        hoping it will be ready next time.
+        """
+        #  num of checks before trying to disconnect
+        max_num_status_ready_before_disconnect = 100
+        count_status_ready = 0
+        max_disconnect = 2
+        count_disconnect = 2
+        time_after_disconnect_sec = 1
+        time_between_checks_sec = 0.01
+
+        try:
+            # check if the board is ready a first time
+            hydradancer_ready = self.device.ctrl_transfer(
+                CTRL_TYPE_VENDOR | CTRL_RECIPIENT_DEVICE | CTRL_IN, self.CHECK_HYDRADANCER_READY,
+                data_or_wLength=1, timeout=5)
+
+            # repeat max_num_status_ready_before_disconnect times
+            while (hydradancer_ready is None or hydradancer_ready == 0) and count_disconnect < max_disconnect:
+                count_status_ready += 1
+                if count_status_ready % max_num_status_ready_before_disconnect == 0 and \
+                   count_disconnect < max_disconnect:
+                    logging.info(
+                        "This is taking too long, disconnecting again ...")
+                    self.disconnect()
+                    time.sleep(time_after_disconnect_sec)
+                    count_disconnect += 1
+                hydradancer_ready = self.device.ctrl_transfer(
+                    CTRL_TYPE_VENDOR | CTRL_RECIPIENT_DEVICE | CTRL_IN, self.CHECK_HYDRADANCER_READY,
+                    data_or_wLength=1, timeout=5)
+                time.sleep(time_between_checks_sec)
+
+            # if hydradancer is still not ready
+            if hydradancer_ready == 0:
+                raise HydradancerBoardFatalError(
+                    "Hydradancer is not ready, please reset the board")
+        except (usb.core.USBTimeoutError, usb.core.USBError) as exception:
+            logging.error(exception)
+            raise HydradancerBoardFatalError(
+                "USB Error while waiting for Hydradancer go-ahead")
+
+    def set_endpoint_mapping(self, ep_num):
+        """
+        Maps emulated endpoints (endpoints facing the target) to Facedancer's host endpoints (control board endpoints)
+        """
+        self.endpoints_mapping[ep_num] = self.endpoints_pool.pop()
+        self.reverse_endpoints_mapping[self.endpoints_mapping[ep_num]] = ep_num
+        try:
+            self.device.ctrl_transfer(CTRL_TYPE_VENDOR | CTRL_RECIPIENT_DEVICE | CTRL_OUT,
+                                      self.SET_ENDPOINT_MAPPING, wValue=(
+                                          ep_num & 0x00ff) | ((self.endpoints_mapping[ep_num] << 8) & 0xff00))
+        except (usb.core.USBTimeoutError, usb.core.USBError) as exception:
+            logging.error(exception)
+            raise HydradancerBoardFatalError(
+                f"Could not set mapping for ep {ep_num}")
+
+    def set_usb2_speed(self, usb2_speed):
+        """
+        Set the speed of the USB2 device. Speed is physically determined by the host,
+        so the emulation board must be configured.
+        """
+        try:
+            self.device.ctrl_transfer(
+                CTRL_TYPE_VENDOR | CTRL_RECIPIENT_DEVICE | CTRL_OUT, self.SET_SPEED, wValue=usb2_speed & 0x00ff)
+        except (usb.core.USBTimeoutError, usb.core.USBError) as exception:
+            logging.error(exception)
+            raise HydradancerBoardFatalError("Error, unable to set speed")
+
+    def set_address(self, address, defer=False):
+        """
+        Set the USB address on the emulation board
+        """
+        try:
+            self.device.ctrl_transfer(
+                CTRL_TYPE_VENDOR | CTRL_RECIPIENT_DEVICE | CTRL_OUT, self.SET_ADDRESS_REQUEST_CODE, address)
+        except (usb.core.USBTimeoutError, usb.core.USBError) as exception:
+            logging.error(exception)
+            raise HydradancerBoardFatalError(
+                "Error, unable to set address on emulated device")
+
+    def stall_endpoint(self, ep_num, direction=0):
+        """
+        Stall the ep_num endpoint on the emulation board.
+        STALL will be cleared automatically after next SETUP packet received.
+        Currently stalls both directions, because ep0 was STALLED only in one direction
+        (TODO maybe separate ep0 from the rest, and double-check).
+        """
+        # Stall EP IN and OUT, then set them to ACK again
+        # direction does not seem to be used (at least for EP0), so stalling would only happen for direction = 0 (OUT)
+        try:
+            self.device.ctrl_transfer(
+                CTRL_TYPE_VENDOR | CTRL_RECIPIENT_DEVICE | CTRL_OUT, self.SET_EP_RESPONSE, wValue=(ep_num | 0 << 7) |
+                (self.ENDP_STATE_STALL << 8) & 0xff00)
+            self.device.ctrl_transfer(
+                CTRL_TYPE_VENDOR | CTRL_RECIPIENT_DEVICE | CTRL_OUT, self.SET_EP_RESPONSE, wValue=(ep_num | 1 << 7) |
+                (self.ENDP_STATE_STALL << 8) & 0xff00)
+        except (usb.core.USBTimeoutError, usb.core.USBError) as exception:
+            logging.error(exception)
+            raise HydradancerBoardFatalError(f"Could not stall ep {ep_num}")
+
+    def send(self, ep_num, data, blocking=False):
+        """
+        Prime target endpoint ep_num. If blocking=True, it will wait for the endpoint's buffer to be empty.
+        """
+        try:
+            self.ep_out[self.endpoints_mapping[ep_num]].write(data)
+            self.ep_status &= ~(0x01 << ep_num)
+            if blocking:
+                while not self.IN_buffer_empty(ep_num):
+                    self.fetch_events()
+        except (usb.core.USBTimeoutError, usb.core.USBError):
+            logging.error(f"could not send data on ep {ep_num}")
+
+    def read(self, ep_num, blocking=False):
+        """
+        Read from target endpoint ep_num. If blocking=True, wait until the endpoint's buffer is full.
+        """
+        logging.debug(f"reading from ep {ep_num}")
+        try:
+            if blocking:
+                while not self.OUT_buffer_available(ep_num):
+                    self.fetch_events()
+            if self.OUT_buffer_available(ep_num):
+                read = self.ep_in[self.endpoints_mapping[ep_num]].read(
+                    self.MAX_PACKET_SIZE)
+                logging.debug(
+                    f"EP{ep_num}/OUT: <- size {len(read)} {bytes(read)}")
+                self.ep_status &= ~((0x01 << ep_num) << 8)
+                return read
+            return None
+        except (usb.core.USBTimeoutError, usb.core.USBError):
+            logging.error(f"could not read data from ep {ep_num}")
+            return None
+
+    def configure(self, endpoint_numbers):
+        for number in endpoint_numbers:
+            self.set_endpoint_mapping(number)
+        logging.info(f"Endpoints mapping {self.endpoints_mapping}")
+        self.configured = True
+
+    def fetch_events(self):
+        """
+        Poll the status of the endpoints. The state are accumulated (like on the boards),
+        and cleared when sending or reading data (which will trigger a similar clear on the boards).
+        Thus, self.ep_status should always be in sync with the endpoint's status on the boards.
+        """
+        try:
+            # Use the endpoint type that best fits the type of request :
+            # -> for control requests, polling using ctrl transfers garanties the fastest status update.
+            #     Latency is key in the enumeration phase
+            # -> for bulk requests, polling using bulk transfers allows for more status updates to be sent,
+            #    thus increasing the speed
+            #  TODO : what about interrupt or isochronous transfers ?
+
+            if not self.configured:
+                read = self.device.ctrl_transfer(
+                    CTRL_TYPE_VENDOR | CTRL_RECIPIENT_DEVICE | CTRL_IN, self.GET_EP_STATUS,
+                    data_or_wLength=self.new_ep_status, timeout=self.timeout_ms_poll)
+            else:
+                read = self.ep_poll.read(
+                    self.new_ep_status, timeout=self.timeout_ms_poll)
+
+            if read > 0:
+                self.ep_status |= (self.new_ep_status[0] & 0x00ff) | (
+                    self.new_ep_status[1] << 8)
+                logging.debug(f"EP status {bin(self.ep_status)}")
+                return True
+            return False
+        except usb.core.USBTimeoutError:
+            return False
+        except usb.core.USBError as exception:
+            logging.error(exception)
+            raise HydradancerBoardFatalError("USB Error while fetching events")
+
+    def IN_buffer_empty(self, ep_num):
+        """
+        Returns True if the IN buffer for target endpoint ep_num is ready for priming
+        """
+        return self.ep_status & (0x1 << ep_num)
+
+    def OUT_buffer_available(self, ep_num):
+        """
+        Returns True if the OUT buffer for target endpoint ep_num is full
+        """
+        return (self.ep_status >> 8) & (0x1 << ep_num)
+
+    def CONTROL_buffer_available(self):
+        """
+        Returns True if the IN buffer for the control endpoint is ready for priming. 
+        Note that currently all control requests (whatever the endpoint num it arrived with) will end up here.
+        """
+        return (self.ep_status >> 8) & (0x1 << 0)

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -744,10 +744,9 @@ class HydradancerBoard():
 
     def CONTROL_buffer_available(self):
         """
-        Returns True if the IN buffer for the control endpoint is ready for priming. 
-        Note that currently all control requests (whatever the endpoint num it arrived with) will end up here.
+        Returns True if the control buffer is available. Since this buffer is shared between EP0 IN/EP0 OUT, only the OUT status is used for both.
         """
-        return self.IN_buffer_empty(0)
+        return self.OUT_buffer_available(0)
 
     def bus_reset_pending(self):
         """

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -298,7 +298,7 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
                     if len(self.ep_transfer_queue[ep_num][0][0]) == 0:
                         self.ep_transfer_queue[ep_num].pop(0)
                 else:
-                    self.connected_device.handle_data_requested(ep)
+                    self.connected_device.handle_nak(ep_num)
 
     # def handle_data_endpoints_legacy(self):
     #     """

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -266,7 +266,7 @@ class HydradancerHostApp(FacedancerApp):
 
         for ep_num, ep in self.ep_in.items():
             if self.api.IN_buffer_empty(ep_num):
-                self.connected_device.handle_buffer_available(ep)
+                self.connected_device.handle_nak(ep)
 
     def handle_control_request(self):
         if not self.api.CONTROL_buffer_available():
@@ -597,7 +597,7 @@ class HydradancerBoard():
         Prime target endpoint ep_num. If blocking=True, it will wait for the endpoint's buffer to be empty.
         """
         try:
-            sent = self.ep_out[self.endpoints_mapping[ep_num]].write(
+            self.ep_out[self.endpoints_mapping[ep_num]].write(
                 data)
             self.hydradancer_status["ep_in_status"] &= ~(0x01 << ep_num)
             if blocking:
@@ -628,6 +628,9 @@ class HydradancerBoard():
             return None
 
     def configure(self, endpoint_numbers):
+        if len(endpoint_numbers) > len(self.endpoints_pool):
+            raise HydradancerBoardFatalError(
+                f"Hydradancer cannot handle {len(endpoint_numbers)} endpoints, only {len(self.endpoints_pool)}")
         for number in endpoint_numbers:
             self.set_endpoint_mapping(number)
         logging.info(f"Endpoints mapping {self.endpoints_mapping}")

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -240,24 +240,16 @@ class HydradancerHostApp(FacedancerApp):
 
         # process ep OUT firsts, transfer is dictated by the host, if there is data available on an ep OUT,
         # it should be processed before setting new IN data
-        for endp in self.configuration.interfaces[0].endpoints:
-            ep_dir_in = usb.util.endpoint_direction(endp) == ENDPOINT_IN
-            ep_num = usb.util.endpoint_address(endp)
-
-            if not ep_dir_in and self.api.OUT_buffer_available(ep_num):
+        for ep_num, ep in self.ep_out.items():
+            if self.api.OUT_buffer_available(ep_num):
                 data = self.api.read(ep_num)
                 if data is not None:
                     self.connected_device.handle_data_available(
                         ep_num, data.tobytes())
 
-        for endp in self.configuration.interfaces[0].endpoints:
-            ep_dir_in = usb.util.endpoint_direction(endp) == ENDPOINT_IN
-            ep_num = usb.util.endpoint_address(endp)
-
-            if ep_dir_in and self.api.IN_buffer_empty(ep_num):
-                ep = self.configuration.get_endpoint(ep_num, ep_dir_in)
-                if ep is not None:
-                    self.connected_device.handle_data_requested(ep)
+        for ep_num, ep in self.ep_in.items():
+            if self.api.IN_buffer_empty(ep_num):
+                self.connected_device.handle_data_requested(ep)
 
     def handle_data_endpoints_legacy(self):
         """
@@ -265,21 +257,16 @@ class HydradancerHostApp(FacedancerApp):
         """
         # process ep OUT firsts, transfer is dictated by the host, if there is data available on an ep OUT,
         # it should be processed before setting new IN data
-        for endp in self.configuration.get_interfaces()[0].endpoints:
-            ep_dir_in = endp.direction == 1
-            ep_num = endp.number
-
-            if not ep_dir_in and self.api.OUT_buffer_available(ep_num):
+        for ep_num, ep in self.ep_out.items():
+            if self.api.OUT_buffer_available(ep_num):
                 data = self.api.read(ep_num)
                 if data is not None:
                     self.connected_device.handle_data_available(
                         ep_num, data.tobytes())
 
-        for endp in self.configuration.get_interfaces()[0].endpoints:
-            ep_dir_in = endp.direction == 1
-            ep_num = endp.number
-            if ep_dir_in and self.api.IN_buffer_empty(ep_num):
-                self.connected_device.handle_buffer_available(ep_num)
+        for ep_num, ep in self.ep_in.items():
+            if self.api.IN_buffer_empty(ep_num):
+                self.connected_device.handle_buffer_available(ep)
 
     def handle_control_request(self):
         if not self.api.CONTROL_buffer_available():

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -10,13 +10,13 @@ import time
 from array import array
 from time import time_ns
 from dataclasses import dataclass
-from typing import List
+from typing import List, Dict, Any
 
 import usb
 from usb.util import CTRL_TYPE_VENDOR, CTRL_RECIPIENT_DEVICE, CTRL_IN, CTRL_OUT
 
 from ..core           import *
-from ..device         import USBDevice, USBConfiguration, USBDirection
+from ..device         import USBDevice, USBConfiguration, USBDirection, USBEndpoint
 from ..types          import DeviceSpeed
 from ..logging        import log
 from .base            import FacedancerBackend
@@ -73,10 +73,10 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
         self.connected_device = None
         self.max_ep0_packet_size = None
 
-        self.ep_transfer_queue = [[]] * self.USB2_MAX_EP_IN
+        self.ep_transfer_queue : List[List[Any]] = [[]] * self.USB2_MAX_EP_IN
 
-        self.ep_in = {}
-        self.ep_out = {}
+        self.ep_in : Dict[int, USBEndpoint] = {}
+        self.ep_out : Dict[int, USBEndpoint] = {}
 
         self.api = HydradancerBoard()
         self.verbose = verbose
@@ -137,7 +137,7 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
         self.configuration = None
         self.pending_control_out_request = None
         self.connected_device = None
-        self.max_ep0_packet_size = None
+        self.max_ep0_packet_size = 0
         self.ep_transfer_queue = [[]] * self.USB2_MAX_EP_IN
         self.api.disconnect()
 
@@ -436,7 +436,7 @@ class HydradancerBoard():
         Get handles on the USB control board, and wait for Hydradancer to be ready
         """
         self.configured = False
-        self.endpoints_mapping = {}
+        self.endpoints_mapping : Dict[int,int] = {}
 
         self.reinit()
 

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -672,13 +672,8 @@ class HydradancerBoard():
         Prime target endpoint ep_num.
         """
         try:
-            start_time = time_ns()
-            MAX_TIME_NS = 1e-3 * 1e9 
             while not self.in_buffer_empty(ep_num):
                 events = self.fetch_events()
-                if (time_ns() - start_time) > MAX_TIME_NS:
-                    logging.debug("Stop waiting to unlock situation")
-                    break
             logging.debug(f"Sending len {len(data)} {data} on ep {ep_num}")
             self.ep_out[self.endpoints_mapping[ep_num]].write(
                 data)


### PR DESCRIPTION
Here are some characteristics and results of this backend, which I think would make it a good addition to this project:
* supports USB2 High-speed, Full-speed and should support low-speed
* 6 endpoints including EP0, in both IN/OUT directions simultaneously
* endpoint numbers from 0 to 7
* increased speed compared to Facedancer21/GreatFET One, results here https://github.com/HydraDancer/hydradancer_fw
* support for NAKs, but also priming using `handle_buffer_empty`
* tested emulation of a mouse peripheral and the included mass storage example
* tested proxy mode with a High-speed USB key (got 1.5MB transfer rate while proxying a 1.5GB file), tested proxy mode with a Full-speed mouse