### PR TITLE
Add note about endpoint numbers to template.py

### DIFF
--- a/examples/template.py
+++ b/examples/template.py
@@ -136,6 +136,7 @@ class TemplateDevice(USBDevice):
                 # properties -- their number and direction.
                 #
                 # Together, these two fields form the endpoint's address.
+                # Endpoint numbers should be > 0, since endpoint 0 is reserved as the default pipe by the spec.
                 number               : int                    = 1
                 direction            : USBDirection           = USBDirection.IN
 


### PR DESCRIPTION
Endpoint 0 is reserved by the spec as the default pipeline. Attempting to emulate a device with an endpoint numbered 0 causes an issue where there is no packet flow after the host is correctly configured. This can be quite painful to debug & is probably a common mistake, since interface numbers are annotated in this template as 'should have a unique index, starting from 0'.