### PR TITLE
LIBUSB_ERROR_BUSY upon shutdown

### DIFF
--- a/facedancer/proxy.py
+++ b/facedancer/proxy.py
@@ -353,8 +353,8 @@ class LibUSB1Device:
             if active_configuration:
                 for interface in active_configuration:
                     number = interface[0].getNumber()
-                    cls.device_handle.attachKernelDriver(number)
                     cls.device_handle.releaseInterface(number)
+                    cls.device_handle.attachKernelDriver(number)
 
             cls.device_handle.close()
             cls.device_handle = None


### PR DESCRIPTION
I just received my Cynthion yesterday - thank you, it's awesome!

However, I'm having a little problem: Upon shutdown, when the libusb context is getting destroyed, I get the error LIBUSB_ERROR_BUSY (using usbproxy):
```
Traceback (most recent call last):
  File "/mnt/source/facedancer/venv/lib/python3.12/site-packages/facedancer/proxy.py", line 356, in _destroy_libusb_context
    cls.device_handle.attachKernelDriver(number)
  File "/mnt/source/facedancer/venv/lib/python3.12/site-packages/usb1/__init__.py", line 1207, in attachKernelDriver
    mayRaiseUSBError(
  File "/mnt/source/facedancer/venv/lib/python3.12/site-packages/usb1/__init__.py", line 127, in mayRaiseUSBError
    __raiseUSBError(value)
  File "/mnt/source/facedancer/venv/lib/python3.12/site-packages/usb1/__init__.py", line 119, in raiseUSBError
    raise __STATUS_TO_EXCEPTION_DICT.get(value, __USBError)(value)
usb1.USBErrorBusy: LIBUSB_ERROR_BUSY [-6]
```

I'm able to properly re-attach the kernel driver when the "attachKernelDriver" and "releaseInterface" calls are swapped around. I don't really know about libusb and its inner workings but I figured I'll just put this up for discussion at least.