### PR TITLE
Correct byte order of bcdUSB and bcdDevice

### DIFF
--- a/examples/template.py
+++ b/examples/template.py
@@ -56,12 +56,12 @@ class TemplateDevice(USBDevice):
     supported_languages      : tuple = (LanguageIDs.ENGLISH_US,)
 
     # The revision of the device hardware. This doesn't matter to the USB specification,
-    # but it's sometimes read by drivers.
-    device_revision          : int  = 0
+    # but it's sometimes read by drivers. 0x0001 represents "0.1" in BCD.
+    device_revision          : int  = 0x0001
 
     # The revision of the USB specification that this device adheres to.
-    # Typically, you'll leave this at '2'.
-    usb_spec_version         : int  = 0x0002
+    # Typically, you'll leave this at 0x0200 which represents "2.0" in BCD.
+    usb_spec_version         : int  = 0x0200
 
 
     #


### PR DESCRIPTION
This will break bcdUSB (`usb_spec_version`) and bcdDevice (`device_revision`) usage in existing scripts that specify them, but I think it is correct to do so as it fixes a bug. The spec is clear about the byte order of these fields and explicitly says "version 2.0 is represented with a value of 0x0200".