### PR TITLE
Fix ZLP bug on CONTROL IN transfers

### DIFF
--- a/facedancer/backends/base.py
+++ b/facedancer/backends/base.py
@@ -93,6 +93,21 @@ class FacedancerBackend:
         raise NotImplementedError
 
 
+    def send_on_control_endpoint(self, endpoint_number: int, in_request: USBControlRequest, data: bytes, blocking: bool=True):
+        """
+        Sends a collection of USB data in response to a IN control request by the host.
+
+        Args:
+            endpoint_number  : The number of the IN endpoint on which data should be sent.
+            in_request       : The control request being responded to.
+            data             : The data to be sent.
+            blocking         : If true, this function should wait for the transfer to complete.
+        """
+        # Truncate data to requested length and forward to `send_on_endpoint()` for backends
+        # that do not need to support this method.
+        return self.send_on_endpoint(endpoint_number, data[:in_request.length], blocking)
+
+
     def send_on_endpoint(self, endpoint_number: int, data: bytes, blocking: bool=True):
         """
         Sends a collection of USB data on a given endpoint.

--- a/facedancer/backends/base.py
+++ b/facedancer/backends/base.py
@@ -130,6 +130,18 @@ class FacedancerBackend:
         raise NotImplementedError
 
 
+    def clear_halt(self, endpoint_number:int, direction: USBDirection):
+        """ Clears a halt condition on the provided non-control endpoint.
+
+        Args:
+            endpoint_number : The endpoint number
+            direction       : The endpoint direction; or OUT if not provided.
+        """
+        # FIXME do nothing as only the moondancer backend supports this for now
+        # raise NotImplementedError
+        pass
+
+
     def service_irqs(self):
         """
         Core routine of the Facedancer execution/event loop. Continuously monitors the

--- a/facedancer/backends/moondancer.py
+++ b/facedancer/backends/moondancer.py
@@ -388,6 +388,21 @@ class MoondancerApp(FacedancerApp, FacedancerBackend):
             log.debug(f"  moondancer.api.stall_endpoint_out({endpoint_number})")
 
 
+    def clear_halt(self, endpoint_number: int, direction: USBDirection):
+        """ Clears a halt condition on the provided non-control endpoint.
+
+        Args:
+            endpoint_number : The endpoint number
+            direction       : The endpoint direction; or OUT if not provided.
+        """
+
+        endpoint_address = (endpoint_number | 0x80) if direction else endpoint_number
+        log.debug(f"Clearing halt EP{endpoint_number} {USBDirection(direction).name} (0x{endpoint_address:x})")
+
+        self.api.clear_feature_endpoint_halt(endpoint_number, direction)
+        log.debug(f"  moondancer.api.clear_feature_endpoint_halt({endpoint_number}, {direction})")
+
+
     def service_irqs(self):
         """
         Core routine of the Facedancer execution/event loop. Continuously monitors the

--- a/facedancer/device.py
+++ b/facedancer/device.py
@@ -247,7 +247,15 @@ class USBBaseDevice(USBDescribable, USBRequestHandler):
         self.backend.stall_endpoint(endpoint_number, direction)
 
 
-    # TODO: add a clear_stall() method here for non-control endpoints
+    def clear_halt(self, endpoint_number: int, direction: USBDirection):
+        """ Clears a halt condition on the provided non-control endpoint.
+
+        Args:
+            endpoint_number : The endpoint number
+            direction       : The endpoint direction; or OUT if not provided.
+        """
+        self.backend.clear_halt(endpoint_number, direction)
+
 
     def send(self, endpoint_number: int, data: bytes, *, blocking: bool = False):
         """ Queues sending data on the IN endpoint with the provided number.

--- a/facedancer/endpoint.py
+++ b/facedancer/endpoint.py
@@ -100,7 +100,7 @@ class USBEndpoint(USBDescribable, AutoInstantiable, USBRequestHandler):
         return self.parent.get_device()
 
 
-    def send(self, data: bytes, *, blocking: bool =False):
+    def send(self, data: bytes, *, blocking: bool = False):
         """ Sends data on this endpoint. Valid only for IN endpoints.
 
         Args:

--- a/facedancer/proxy.py
+++ b/facedancer/proxy.py
@@ -245,7 +245,7 @@ class USBProxyDevice(USBBaseDevice):
             self.backend.stall_endpoint(0, USBDirection.IN)
         else:
             # TODO: support control endpoints other than 0
-            self.send(0, data)
+            self.control_send(0, request, data)
 
 
     def _proxy_out_control_request(self, request: USBControlRequest):

--- a/facedancer/request.py
+++ b/facedancer/request.py
@@ -251,7 +251,7 @@ class USBControlRequest:
 
     def reply(self, data: bytes):
         """ Replies to the given request with a given set of bytes. """
-        self.device.send(endpoint_number=0, data=data)
+        self.device.control_send(endpoint_number=0, in_request=self, data=data)
 
 
     def acknowledge(self, *, blocking: bool = False):
@@ -260,7 +260,7 @@ class USBControlRequest:
         Args:
             blocking : If true, the relevant control request will complete before returning.
         """
-        self.device.send(endpoint_number=0, data=b"", blocking=blocking)
+        self.device.control_send(endpoint_number=0, in_request=self, data=b"", blocking=blocking)
 
 
     def ack(self, *, blocking: bool = False):


### PR DESCRIPTION
Cynthion requires the length field of any CONTROL IN transfer request in order to negotiate the transfer acknowledgement successfully.

This PR extends the Facedancer backend API as well as the core implementation to:

* Provide a new `USBDevice` method: `control_send(self, endpoint_number: int, in_request: USBControlRequest, data: bytes, *, blocking: bool = False)`
* Provide a new backend method: `send_on_control_endpoint(self, endpoint_number: int, in_request: USBControlRequest, data: bytes, blocking: bool=True)`
* A backwards compatible default implementation for Facedancer boards that do not need this method which:
  * Will use the length field to truncate transfers to the requested length, fixing a long-standing bug.
  * Allows the `USBControlRequest` to be modified by filters in USB Proxy or custom control handlers in Facedancer devices.

