### PR TITLE
Allow Control-C to gracefully exit a Facedancer emulation

### DIFF
--- a/examples/coroutine.py
+++ b/examples/coroutine.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# pylint: disable=unused-wildcard-import, wildcard-import
+#
+# This file is part of Facedancer.
+#
+
+import asyncio
+import sys
+
+from facedancer         import *
+from facedancer.errors  import EndEmulation
+from facedancer.logging import configure_default_logging, log
+
+from minimal import MyDevice
+
+
+async def my_exit_handler(bindkey: bytes):
+    """A custom exit handler that will gracefully shut down the
+        emulation when the user presses the given key combination.
+    """
+    import platform
+    if platform.system() == "Windows":
+        import msvcrt
+        def get_key():
+          key = msvcrt.getch()
+          # check for, and propagate Control-C
+          if key == b'\x03':
+              raise KeyboardInterrupt
+          return key
+    else:
+        import termios, tty
+        def get_key():
+          fd = sys.stdin.fileno()
+          restore = termios.tcgetattr(fd)
+          try:
+              tty.setcbreak(fd)
+              key = sys.stdin.read(1)
+          finally:
+              termios.tcsetattr(fd, termios.TCSADRAIN, restore)
+          return str.encode(key)
+
+    while True:
+        key = get_key()
+        if key == bindkey:
+            raise EndEmulation("User quit the emulation.")
+        await asyncio.sleep(0)
+
+
+def my_main_function(device, *coroutines):
+    """
+    A custom main function for emulating a Facedancer device.
+    """
+
+    # Set up our logging output.
+    configure_default_logging(level=20)
+
+    # Add a custom exit handler to our coroutines.
+    coroutines = (*coroutines, my_exit_handler(b'\x05'))
+
+    # Run the relevant code, along with any added coroutines.
+    log.info("Starting emulation, press 'Control-E' to disconnect and exit.")
+    device.emulate(*coroutines)
+
+
+if __name__ == "__main__":
+    my_main_function(MyDevice())

--- a/examples/minimal.py
+++ b/examples/minimal.py
@@ -51,4 +51,5 @@ class MyDevice(USBDevice):
         request.ack()
 
 
-main(MyDevice)
+if __name__ == "__main__":
+    main(MyDevice)

--- a/facedancer/device.py
+++ b/facedancer/device.py
@@ -14,6 +14,7 @@ from dataclasses    import dataclass, field
 from prompt_toolkit import HTML, print_formatted_text
 
 from .core          import FacedancerUSBApp
+from .errors        import EndEmulation
 from .types         import DescriptorTypes, LanguageIDs, USBStandardRequests
 from .types         import USBDirection, USBRequestType, USBRequestRecipient
 from .types         import DeviceSpeed
@@ -226,6 +227,8 @@ class USBBaseDevice(USBDescribable, USBRequestHandler):
 
         try:
             self.run_with(*coroutines)
+        except EndEmulation as e:
+            log.info(f"{e}")
         finally:
             self.disconnect()
 

--- a/facedancer/devices/__init__.py
+++ b/facedancer/devices/__init__.py
@@ -8,7 +8,8 @@ import asyncio
 import inspect
 import argparse
 
-from ..logging import configure_default_logging
+from ..errors  import EndEmulation
+from ..logging import configure_default_logging, log
 
 def default_main(device_or_type, *coroutines):
     """ Simple, default main for Facedancer emulation.
@@ -38,7 +39,11 @@ def default_main(device_or_type, *coroutines):
         sys.exit(0)
 
     # Run the relevant code, along with any added coroutines.
-    device.emulate(*coroutines)
-
-    if args.suggest:
-        device.print_suggested_additions()
+    log.info("Starting emulation, press 'Control-C' to disconnect and exit.")
+    try:
+        device.emulate(*coroutines)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if args.suggest:
+            device.print_suggested_additions()

--- a/facedancer/errors.py
+++ b/facedancer/errors.py
@@ -5,3 +5,6 @@
 class DeviceNotFoundError(IOError):
     """ Error indicating a device was not found. """
     pass
+
+class EndEmulation(Exception):
+    """ When an EndEmulation exception is thrown the emulation will shutdown and exit. """


### PR DESCRIPTION
This PR attempts to resolve the tension between:

- Being able to exit an emulation in order for a) the `--suggest` argument to work and b) just having something nicer than crashing out of the emulation with a `SIGINT` versus…
- Not interfering with any external scripts running one or more emulations.

~~I propose that we dedicate an unused key-combination (at the time of writing this is `Control-E`) that can be polled for in an `exit_handler()` co-routine.~~

The final approach taken is to catch the `KeyboardInterrupt` exception in the `default_main()` helper function allowing users to gracefully exit from the emulation by pressing `Control-C`.

For users who may require different behavior a new example has been added: `examples/coroutine.py` which demonstrates how to write a custom `default_main` function and the use of coroutines.


---
Closes #118 