### PR TITLE
HIDReportDescriptor: return raw bytes when available

### DIFF
--- a/facedancer/backends/moondancer.py
+++ b/facedancer/backends/moondancer.py
@@ -256,7 +256,7 @@ class MoondancerApp(FacedancerApp, FacedancerBackend):
             configuration : The USBConfiguration object applied by the SET_CONFIG request.
         """
 
-        log.debug("fmoondancer.configured({configuration})")
+        log.debug(f"moondancer.configured({configuration})")
 
         if configuration is None:
             log.error("Target host configuration could not be applied.")

--- a/facedancer/classes/hid/descriptor.py
+++ b/facedancer/classes/hid/descriptor.py
@@ -116,21 +116,22 @@ class HIDCollection(IntEnum):
     VENDOR         = 0xFF
 
 
-
 @dataclass
 class HIDReportDescriptor(USBDescriptor):
     """ Descriptor class representing a HID report descriptor. """
 
     # Parameter where the user defines the descriptor's fields.
-    fields : Iterable[bytes] = ()
+    fields: Iterable[bytes] = ()
 
     # Mark this as a HID report descriptor.
-    number : int    = USBDescriptorTypeNumber.REPORT
-    raw    : None   = None
-
+    number: int = USBDescriptorTypeNumber.REPORT
+    raw: None | bytes = None
 
     def __call__(self, index=0):
         """ Converts the descriptor object into raw bytes. """
+
+        if self.raw is not None:
+            return self.raw
 
         raw = bytearray()
 


### PR DESCRIPTION
Hi there :wave:,

I would like to utilize the `HIDReportDescriptor` class by initializing it with raw bytes.
This PR checks for raw bytes being available and returns them first or will fall back to converting the descriptor object.

Thanks you & best regards,
Jan