### PR TITLE
repo: support nested type annotations on Python < 3.9

### DIFF
--- a/facedancer/device.py
+++ b/facedancer/device.py
@@ -3,6 +3,9 @@
 #
 """ Functionality for defining USB devices. """
 
+# Support annotations on Python < 3.9
+from __future__  import annotations
+
 import sys
 import asyncio
 import struct

--- a/facedancer/endpoint.py
+++ b/facedancer/endpoint.py
@@ -3,6 +3,9 @@
 #
 """ Functionality for describing USB endpoints. """
 
+# Support annotations on Python < 3.9
+from __future__  import annotations
+
 import struct
 
 from typing      import Iterable, List, Dict

--- a/facedancer/interface.py
+++ b/facedancer/interface.py
@@ -3,6 +3,9 @@
 #
 """ Functionality for defining USB interfaces. """
 
+# Support annotations on Python < 3.9
+from __future__  import annotations
+
 import struct
 
 from typing       import Dict, List, Iterable


### PR DESCRIPTION
Nested type annotations are only supported from 3.9 onwards.

e.g. 

```
attached_descriptors : List[USBDescriptor] = field(default_factory=list)
```