### PR TITLE
moondancer: log a warning for permissions errors

### DIFF
--- a/facedancer/backends/moondancer.py
+++ b/facedancer/backends/moondancer.py
@@ -164,6 +164,9 @@ class MoondancerApp(FacedancerApp, FacedancerBackend):
         except ImportError:
             log.info("Skipping Cynthion-based devices, as the cynthion python module isn't installed.")
             return False
+        except IOError:
+            log.warning("Found Cynthion-based device, but could not access it. (Check permissions?)")
+            return False
         except:
             return False
 


### PR DESCRIPTION
If there's a Cynthion device available but libgreat couldn't claim access to it, it throws an IOError. This catches that and logs a message for the user.