### PR TITLE
Get rubber-ducky example working with new descriptor features.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!--
 ## [Unreleased]
+### Fixed
+* Updated Keyboard device / rubber-ducky to work with new descriptor handling features.
 -->
 
 ## [3.0.5] - 2024-11-25
@@ -88,7 +90,7 @@ Any future bug-fixes or backports to Facedancer `2.9.x` should use the [`v2.9.x 
 
 
 [Unreleased]: https://github.com/greatscottgadgets/facedancer/compare/3.0.5...HEAD
-[3.0.5]: https://github.com/greatscottgadgets/facedancer/compare/3.0.5...3.0.5
+[3.0.5]: https://github.com/greatscottgadgets/facedancer/compare/3.0.4...3.0.5
 [3.0.4]: https://github.com/greatscottgadgets/facedancer/compare/3.0.3...3.0.4
 [3.0.3]: https://github.com/greatscottgadgets/facedancer/compare/3.0.2...3.0.3
 [3.0.2]: https://github.com/greatscottgadgets/facedancer/compare/3.0.1...3.0.2

--- a/facedancer/classes/hid/descriptor.py
+++ b/facedancer/classes/hid/descriptor.py
@@ -3,6 +3,9 @@
 #
 """ Code for implementing HID classes. """
 
+# Support annotations on Python < 3.9
+from __future__  import annotations
+
 from enum        import IntEnum
 from dataclasses import dataclass
 from typing      import Tuple, Iterable
@@ -124,8 +127,8 @@ class HIDReportDescriptor(USBDescriptor):
     fields: Iterable[bytes] = ()
 
     # Mark this as a HID report descriptor.
-    number: int = USBDescriptorTypeNumber.REPORT
-    raw: None | bytes = None
+    type_number : int = USBDescriptorTypeNumber.REPORT
+    raw         : None | bytes = None
 
     def __call__(self, index=0):
         """ Converts the descriptor object into raw bytes. """

--- a/facedancer/descriptor.py
+++ b/facedancer/descriptor.py
@@ -72,7 +72,7 @@ class USBDescriptor(USBDescribable, AutoInstantiable):
 class USBClassDescriptor(USBDescriptor):
     """ Class for arbitrary USB Class descriptors. """
 
-    include_in_config = True
+    include_in_config : bool = True
 
     def __init_subclass__(cls, **kwargs):
         warn(

--- a/facedancer/devices/keyboard.py
+++ b/facedancer/devices/keyboard.py
@@ -51,11 +51,14 @@ class USBKeyboardDevice(USBDevice):
 
 
             class HIDDescriptor(USBDescriptor):
-                number      : int   =  USBDescriptorTypeNumber.HID
-                raw         : bytes = b'\x09\x21\x10\x01\x00\x01\x22\x2b\x00'
+                number            : int   = 0
+                type_number       : int   = USBDescriptorTypeNumber.HID
+                raw               : bytes = b'\x09\x21\x10\x01\x00\x01\x22\x2b\x00'
+                include_in_config : bool  = True
 
 
             class ReportDescriptor(HIDReportDescriptor):
+                number : int   =  0
                 fields : tuple = (
 
                     # Identify ourselves as a keyboard.


### PR DESCRIPTION
This PR does a bunch of things:

* There is some ancient confusion in bits of the codebase when referring to a descriptor's `number` and `type_number`. The `number` is the descriptor _number_ whereas `type_number` is the descriptor _type_. This was causing identifier lookups to fail when searching for a descriptor in `requestable_descriptors`.
* The `Keyboard` device's `HIDDescriptor` also needed to specify `include_in_config`.
* The data class for `USBClassDescriptor` needed a type annotation.


---

closes #133 