### PR TITLE
Check for active_configuration before using it.

### DIFF
--- a/facedancer/configuration.py
+++ b/facedancer/configuration.py
@@ -148,10 +148,11 @@ class USBConfiguration(USBDescribable, AutoInstantiable, USBRequestHandler):
         """
 
         # Search each of our interfaces for the relevant endpoint.
-        for interface in self.active_interfaces.values():
-            endpoint = interface.get_endpoint(number, direction)
-            if endpoint is not None:
-                return endpoint
+        if hasattr(self, 'active_interfaces'):
+            for interface in self.active_interfaces.values():
+                endpoint = interface.get_endpoint(number, direction)
+                if endpoint is not None:
+                    return endpoint
 
         # If none have one, return None.
         return None
@@ -175,10 +176,11 @@ class USBConfiguration(USBDescribable, AutoInstantiable, USBRequestHandler):
             data     : The raw bytes received on the relevant endpoint.
         """
 
-        for interface in self.active_interfaces.values():
-            if interface.has_endpoint(endpoint.number, direction=USBDirection.OUT):
-                interface.handle_data_received(endpoint, data)
-                return
+        if hasattr(self, 'active_interfaces'):
+            for interface in self.active_interfaces.values():
+                if interface.has_endpoint(endpoint.number, direction=USBDirection.OUT):
+                    interface.handle_data_received(endpoint, data)
+                    return
 
         # If no interface owned the targeted endpoint, consider the data unexpected.
         self.get_device().handle_unexpected_data_received(endpoint.number, data)
@@ -195,10 +197,11 @@ class USBConfiguration(USBDescribable, AutoInstantiable, USBRequestHandler):
             endpoint : The endpoint on which the host requested data.
         """
 
-        for interface in self.active_interfaces.values():
-            if interface.has_endpoint(endpoint.number, direction=USBDirection.IN):
-                interface.handle_data_requested(endpoint)
-                return
+        if hasattr(self, 'active_interfaces'):
+            for interface in self.active_interfaces.values():
+                if interface.has_endpoint(endpoint.number, direction=USBDirection.IN):
+                    interface.handle_data_requested(endpoint)
+                    return
 
         # If no one interface owned the targeted endpoint, consider the data unexpected.
         self.get_device().handle_unexpected_data_requested(endpoint.number)
@@ -214,10 +217,11 @@ class USBConfiguration(USBDescribable, AutoInstantiable, USBRequestHandler):
         This function is called only once per buffer.
         """
 
-        for interface in self.active_interfaces.values():
-            if interface.has_endpoint(endpoint.number, direction=USBDirection.IN):
-                interface.handle_buffer_empty(endpoint)
-                return
+        if hasattr(self, 'active_interfaces'):
+            for interface in self.active_interfaces.values():
+                if interface.has_endpoint(endpoint.number, direction=USBDirection.IN):
+                    interface.handle_buffer_empty(endpoint)
+                    return
 
 
 


### PR DESCRIPTION
Using `usbproxy.py` with an older Yubikey results in this error when the target system attempts to attach the device via the proxy.

```
INFO    | logging        | [17:55:07] USBControlRequest(direction=1, type=0, recipient=1, number=6, value=8704, index=0, length=71, data=bytearray(b''), device=USBProxyDevice(name='generic device', device_class=0, device_subclass=0, protocol_revision_number=0, max_packet_size_ep0=64, vendor_id=24843, product_id=18003, manufacturer_string='Facedancer', product_string='Generic USB Device', serial_number_string='S/N 3420E', supported_languages=(<LanguageIDs.ENGLISH_US: 1033>,), device_revision=0, usb_spec_version=512, device_speed=None, requestable_descriptors={<DescriptorTypes.DEVICE: 1>: <function USBBaseDevice.__post_init__.<locals>.<lambda> at 0x7efffe1984a0>, <DescriptorTypes.CONFIGURATION: 2>: <bound method USBBaseDevice.get_configuration_descriptor of ...>, <DescriptorTypes.STRING: 3>: <bound method USBBaseDevice.get_string_descriptor of ...>}, configurations={}, backend=<facedancer.backends.greatdancer.GreatDancerApp object at 0x7efffd0c1590>))
INFO    | logging        | [17:55:07] <: b'\x05\x01\t\x06\xa1\x01\x05\x07\x19\xe0)\xe7\x15\x00%\x01u\x01\x95\x08\x81\x02\x95\x01u\x08\x81\x01\x95\x05u\x01\x05\x08\x19\x01)\x05\x91\x02\x95\x01u\x03\x91\x01\x95\x06u\x08\x15\x00%e\x05\x07\x19\x00)e\x81\x00\t\x03u\x08\x95\x08\xb1\x02\xc0'
TRACE   | greatdancer    | EP0/IN: <- b'\x05\x01\t\x06\xa1\x01\x05\x07\x19\xe0)\xe7\x15\x00%\x01u\x01\x95\x08\x81\x02\x95\x01u\x08\x81\x01\x95\x05u\x01\x05\x08\x19\x01)\x05\x91\x02\x95\x01u\x03\x91\x01\x95\x06u\x08\x15\x00%e\x05\x07\x19\x00)e\x81\x00\t\x03u\x08\x95\x08\xb1\x02\xc0'
INFO    | greatdancer    | Disconnecting from host.
Traceback (most recent call last):
  File "/home/user/hack/usb/facedancer/examples/usbproxy.py", line 29, in <module>
    main(proxy)
  File "/home/user/hack/usb/facedancer/facedancer/devices/__init__.py", line 44, in default_main
    device.emulate(*coroutines)
  File "/home/user/hack/usb/facedancer/facedancer/device.py", line 234, in emulate
    self.run_with(*coroutines)
  File "/home/user/hack/usb/facedancer/facedancer/device.py", line 219, in run_with
    asyncio.run(inner())
  File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/user/hack/usb/facedancer/facedancer/device.py", line 217, in inner
    await asyncio.gather(self.run(), *coroutines)
  File "/home/user/hack/usb/facedancer/facedancer/device.py", line 206, in run
    self.backend.service_irqs()
  File "/home/user/hack/usb/facedancer/facedancer/backends/greatdancer.py", line 792, in service_irqs
    self._handle_transfer_events()
  File "/home/user/hack/usb/facedancer/facedancer/backends/greatdancer.py", line 496, in _handle_transfer_events
    self._handle_transfer_readiness()
  File "/home/user/hack/usb/facedancer/facedancer/backends/greatdancer.py", line 642, in _handle_transfer_readiness
    self.connected_device.handle_buffer_available(endpoint.number)
  File "/home/user/hack/usb/facedancer/facedancer/device.py", line 383, in handle_buffer_available
    endpoint = self.get_endpoint(ep_num, USBDirection.IN)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/hack/usb/facedancer/facedancer/device.py", line 344, in get_endpoint
    endpoint = self.configuration.get_endpoint(endpoint_number, direction)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/hack/usb/facedancer/facedancer/configuration.py", line 151, in get_endpoint
    for interface in self.active_interfaces.values():
                     ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'USBConfiguration' object has no attribute 'active_interfaces'. Did you mean: 'get_interfaces'?
```

Proxying system is Linux and target system is macOS.

The issue seems to be that the `USBConfiguration` class assumes `active_interfaces` always exists. However that not always the case it seems. Adding an explicit check for it resolves the issue for me and the proxied device works as expected.