### PR TITLE
Reject unsupported configurations in backends

### DIFF
--- a/facedancer/backends/MAXUSBApp.py
+++ b/facedancer/backends/MAXUSBApp.py
@@ -232,8 +232,8 @@ class MAXUSBApp(FacedancerApp, FacedancerBackend):
         Args:
             configuration : The configuration applied by the SET_CONFIG request.
         """
+        self.validate_configuration(configuration)
 
         # For the MAXUSB case, we don't need to do anything, though it might
         # be nice to print a message or store the active configuration for
         # use by the USBDevice, etc. etc.
-        pass

--- a/facedancer/backends/base.py
+++ b/facedancer/backends/base.py
@@ -163,3 +163,31 @@ class FacedancerBackend:
         Facedancer's execution status, and reacts as events occur.
         """
         raise NotImplementedError
+
+
+    def validate_configuration(self, configuration: USBConfiguration):
+        """
+        Check if this backend is able to support this configuration.
+        Raises an exception if it is not.
+
+        Args:
+            configuration : The configuration to validate.
+        """
+        if configuration is None:
+            return
+
+        # Currently, endpoints are only set up in the configured() method, and
+        # cannot be changed on the fly by SET_INTERFACE requests.
+        #
+        # Therefore, no backends are able to support configurations which
+        # re-use endpoint addresses between alternate interface settings.
+        used_addresses = set()
+        for interface in configuration.get_interfaces():
+            for endpoint in interface.get_endpoints():
+                address = endpoint.get_identifier()
+                if address in used_addresses:
+                    raise Exception(
+                        f"This configuration cannot currently be supported, "
+                        f"because it re-uses endpoint address 0x{address:02X} "
+                        f"between multiple interface definitions.")
+                used_addresses.add(address)

--- a/facedancer/backends/greatdancer.py
+++ b/facedancer/backends/greatdancer.py
@@ -763,6 +763,7 @@ class GreatDancerApp(FacedancerApp, FacedancerBackend):
         Args:
             configuration: The configuration applied by the SET_CONFIG request.
         """
+        self.validate_configuration(configuration)
         self._configure_endpoints(configuration)
         self.configuration = configuration
 

--- a/facedancer/backends/hydradancer.py
+++ b/facedancer/backends/hydradancer.py
@@ -168,6 +168,7 @@ class HydradancerHostApp(FacedancerApp, FacedancerBackend):
         Args:
             configuration : The USBConfiguration object applied by the SET_CONFIG request.
         """
+        self.validate_configuration(configuration)
 
         if configuration is None:
             self.configuration = None

--- a/facedancer/backends/moondancer.py
+++ b/facedancer/backends/moondancer.py
@@ -258,6 +258,7 @@ class MoondancerApp(FacedancerApp, FacedancerBackend):
         Args:
             configuration : The USBConfiguration object applied by the SET_CONFIG request.
         """
+        self.validate_configuration(configuration)
 
         log.debug(f"moondancer.configured({configuration})")
 


### PR DESCRIPTION
PR #122 added support for alternate interface settings, but currently, backends only set up endpoints on a call to `configured()`, and have no API to support changing which endpoints are in use on a `SET_INTERFACE` request.

However, it turns out that things mostly work anyway, because current backends will simply iterate over all interface definitions when looking for endpoints to set up, and thereby set up the union of all endpoint addresses used by any interface definitions in the configuration.

This is actually a viable approach, _provided_ that none of these endpoint addresses are used in different ways by multiple interface definitions. Therefore, rather than trying to implement on-the-fly remapping of available endpoints in each backend, for now we can simply reject configurations which use overlapping endpoint addresses.

This PR implements this by adding a `validate_configuration` method to `FacedancerBackend`, which is called by each backend's `configured` method before using the configuration provided.

Individual backends could also override this method to add additional constraints of their own, such as limits on the total endpoints used.

