### PR TITLE
Use a bit less magic

### DIFF
--- a/facedancer/configuration.py
+++ b/facedancer/configuration.py
@@ -251,8 +251,7 @@ class USBConfiguration(USBDescribable, AutoInstantiable, USBRequestHandler):
         # FIXME: use construct
 
         # All all subordinate descriptors together to create a big subordinate descriptor.
-        interfaces = sorted(self.interfaces.values(), key=lambda item: item.get_identifier())
-        for interface in interfaces:
+        for interface in self.interfaces.values():
             interface_descriptors += interface.get_descriptor()
 
         total_len      = len(interface_descriptors) + 9

--- a/facedancer/magic.py
+++ b/facedancer/magic.py
@@ -31,21 +31,14 @@ class AutoInstantiator:
     at the cost of being somewhat cryptic.
     """
 
-    def __init__(self, target_type, identifier=None):
+    def __init__(self, target_type):
         self._target_type = target_type
-        self._identifier  = identifier
 
     def creates_instance_of(self, expected_type):
         return issubclass(self._target_type, expected_type)
 
     def __call__(self, parent):
-        instance   = self._target_type(parent=parent)
-        identifier = self._identifier
-
-        if identifier is None:
-            identifier = instance.get_identifier()
-
-        return identifier, instance
+        return self._target_type(parent=parent)
 
 
 def use_automatically(cls):
@@ -108,14 +101,7 @@ def instantiate_subordinates(obj, expected_type):
     objects of any inner class decorated with ``@use_automatically``.
     """
 
-    instances = {}
-
     # Search our class for anything decorated with an AutoInstantiator of the relevant type.
     for _, member in inspect.getmembers(obj):
         if isinstance(member, AutoInstantiator) and member.creates_instance_of(expected_type):
-
-            # And instantiate it.
-            identifier, target = member(obj)
-            instances[identifier] = target
-
-    return instances
+            yield member(object)

--- a/facedancer/magic.py
+++ b/facedancer/magic.py
@@ -74,7 +74,7 @@ def use_automatically(cls):
 
 def _use_inner_classes_automatically(cls):
     # Iterate over the relevant class...
-    for name, member in inspect.getmembers(cls):
+    for name, member in cls.__dict__.items():
 
         # ... and tag each inner class with both use_automatically
         # -and- use_inner_classes_automatically. The former
@@ -102,6 +102,6 @@ def instantiate_subordinates(obj, expected_type):
     """
 
     # Search our class for anything decorated with an AutoInstantiator of the relevant type.
-    for _, member in inspect.getmembers(obj):
+    for member in type(obj).__dict__.values():
         if isinstance(member, AutoInstantiator) and member.creates_instance_of(expected_type):
             yield member(object)


### PR DESCRIPTION
Reduces the amount of magic involved in auto-instantiating classes.

- The `instantiate_subordinates` helper now just returns a generator of instances, rather than a `dict` which would silently lose any instances with duplicate identifiers.
- At each call site of `instantiate_subordinates`, duplicate identifiers are checked for, and appropriate errors reported.
- Orders are maintained, so that objects will appear in a binary configuration in the same order in which they were declared/added to their parent objects.

Depends on #139.