### PR TITLE
Descriptor API tweaks

### DIFF
--- a/facedancer/__init__.py
+++ b/facedancer/__init__.py
@@ -17,7 +17,8 @@ from .types         import USBRequestType, USBRequestRecipient, USBStandardReque
 from .types         import DeviceSpeed
 
 # Decorators.
-from .magic import use_automatically, use_inner_classes_automatically
+from .magic         import use_automatically, use_inner_classes_automatically
+from .descriptor    import include_in_config, requestable
 
 # Alias objects to make them easier to import.
 from .backends import *
@@ -33,5 +34,5 @@ __all__ = [
     'USBDirection', 'USBTransferType', 'USBUsageType', 'USBSynchronizationType',
     'USBRequestType', 'USBRequestRecipient', 'USBStandardRequests', 'LanguageIDs',
     'DeviceSpeed', 'use_automatically', 'use_inner_classes_automatically',
-    'USBControlRequest',
+    'USBControlRequest', 'include_in_config', 'requestable',
 ]

--- a/facedancer/__init__.py
+++ b/facedancer/__init__.py
@@ -3,7 +3,7 @@ from .device        import USBDevice
 from .configuration import USBConfiguration
 from .interface     import USBInterface
 from .endpoint      import USBEndpoint
-from .descriptor    import USBDescriptor, USBClassDescriptor, USBDescriptorTypeNumber
+from .descriptor    import USBDescriptor, USBClassDescriptor, USBDescriptorTypeNumber, StringRef
 
 # Control request handlers.
 from .request       import standard_request_handler, class_request_handler, vendor_request_handler
@@ -34,5 +34,5 @@ __all__ = [
     'USBDirection', 'USBTransferType', 'USBUsageType', 'USBSynchronizationType',
     'USBRequestType', 'USBRequestRecipient', 'USBStandardRequests', 'LanguageIDs',
     'DeviceSpeed', 'use_automatically', 'use_inner_classes_automatically',
-    'USBControlRequest', 'include_in_config', 'requestable',
+    'USBControlRequest', 'include_in_config', 'requestable', 'StringRef',
 ]

--- a/facedancer/classes/hid/descriptor.py
+++ b/facedancer/classes/hid/descriptor.py
@@ -7,7 +7,6 @@
 from __future__  import annotations
 
 from enum        import IntEnum
-from dataclasses import dataclass
 from typing      import Tuple, Iterable
 
 from ...descriptor import USBDescriptor, USBDescriptorTypeNumber
@@ -119,7 +118,6 @@ class HIDCollection(IntEnum):
     VENDOR         = 0xFF
 
 
-@dataclass
 class HIDReportDescriptor(USBDescriptor):
     """ Descriptor class representing a HID report descriptor. """
 

--- a/facedancer/configuration.py
+++ b/facedancer/configuration.py
@@ -49,7 +49,7 @@ class USBConfiguration(USBDescribable, AutoInstantiable, USBRequestHandler):
 
 
     @classmethod
-    def from_binary_descriptor(cls, data):
+    def from_binary_descriptor(cls, data, strings={}):
         """
         Generates a new USBConfiguration object from a configuration descriptor,
         handling any attached subordinate descriptors.
@@ -66,7 +66,7 @@ class USBConfiguration(USBDescribable, AutoInstantiable, USBRequestHandler):
 
         configuration = cls(
             number=index,
-            configuration_string=string_index,
+            configuration_string=None if string_index == 0 else strings[string_index],
             max_power=half_max_power * 2,
             self_powered=bool((attributes >> 6) & 1),
             supports_remote_wakeup=bool((attributes >> 5) & 1),
@@ -81,7 +81,7 @@ class USBConfiguration(USBDescribable, AutoInstantiable, USBRequestHandler):
 
             # Determine the length and type of the next descriptor.
             length     = data[0]
-            descriptor = USBDescribable.from_binary_descriptor(data[:length])
+            descriptor = USBDescribable.from_binary_descriptor(data[:length], strings=strings)
 
             # If we have an interface descriptor, add it to our list of interfaces.
             if isinstance(descriptor, USBInterface):

--- a/facedancer/configuration.py
+++ b/facedancer/configuration.py
@@ -13,7 +13,7 @@ from .magic       import instantiate_subordinates, AutoInstantiable
 from .request     import USBRequestHandler
 
 from .interface   import USBInterface
-from .descriptor  import USBDescribable, USBDescriptor
+from .descriptor  import USBDescribable, USBDescriptor, StringRef
 from .endpoint    import USBEndpoint
 
 
@@ -35,7 +35,7 @@ class USBConfiguration(USBDescribable, AutoInstantiable, USBRequestHandler):
     DESCRIPTOR_SIZE_BYTES   = 9
 
     number                 : int            = 1
-    configuration_string   : str            = None
+    configuration_string   : StringRef      = None
 
     max_power              : int            = 500
 
@@ -64,7 +64,7 @@ class USBConfiguration(USBDescribable, AutoInstantiable, USBRequestHandler):
 
         configuration = cls(
             number=index,
-            configuration_string=None if string_index == 0 else strings[string_index],
+            configuration_string=StringRef.lookup(strings, string_index),
             max_power=half_max_power * 2,
             self_powered=bool((attributes >> 6) & 1),
             supports_remote_wakeup=bool((attributes >> 5) & 1),
@@ -103,6 +103,8 @@ class USBConfiguration(USBDescribable, AutoInstantiable, USBRequestHandler):
 
 
     def __post_init__(self):
+
+        self.configuration_string = StringRef.ensure(self.configuration_string)
 
         # Gather any interfaces attached to the configuration.
         for interface in instantiate_subordinates(self, USBInterface):

--- a/facedancer/configuration.py
+++ b/facedancer/configuration.py
@@ -251,8 +251,7 @@ class USBConfiguration(USBDescribable, AutoInstantiable, USBRequestHandler):
         # FIXME: use construct
 
         # All all subordinate descriptors together to create a big subordinate descriptor.
-        interfaces = sorted(self.interfaces.values(), key=lambda item: item.get_identifier())
-        for interface in interfaces:
+        for interface in self.interfaces.values():
             interface_descriptors += interface.get_descriptor()
 
         total_len      = len(interface_descriptors) + 9

--- a/facedancer/configuration.py
+++ b/facedancer/configuration.py
@@ -5,7 +5,7 @@
 
 import struct
 
-from dataclasses  import dataclass, field
+from dataclasses  import field
 from typing       import Iterable
 
 from .types       import USBDirection
@@ -17,8 +17,6 @@ from .descriptor  import USBDescribable, USBDescriptor
 from .endpoint    import USBEndpoint
 
 
-
-@dataclass
 class USBConfiguration(USBDescribable, AutoInstantiable, USBRequestHandler):
     """ Class representing a USBDevice's configuration.
 

--- a/facedancer/configuration.py
+++ b/facedancer/configuration.py
@@ -68,8 +68,8 @@ class USBConfiguration(USBDescribable, AutoInstantiable, USBRequestHandler):
             number=index,
             configuration_string=string_index,
             max_power=half_max_power * 2,
-            self_powered=(attributes >> 6) & 1,
-            supports_remote_wakeup=(attributes >> 5) & 1,
+            self_powered=bool((attributes >> 6) & 1),
+            supports_remote_wakeup=bool((attributes >> 5) & 1),
         )
 
         data = data[length:total_length]

--- a/facedancer/descriptor.py
+++ b/facedancer/descriptor.py
@@ -3,7 +3,7 @@
 #
 """ Functionality for working with objects with associated USB descriptors. """
 
-from .magic import AutoInstantiable, DescribableMeta
+from .magic import AutoInstantiable, DescribableMeta, adjust_defaults
 
 from enum import IntEnum
 from warnings import warn
@@ -183,3 +183,13 @@ class USBDescriptorTypeNumber(IntEnum):
     INTERFACE_POWER           = 8
     HID                       = 33
     REPORT                    = 34
+
+
+def include_in_config(cls):
+    """ Decorator that marks a descriptor to be included in configuration data. """
+    return adjust_defaults(cls, include_in_config=True)
+
+
+def requestable(type_number, number):
+    """ Decorator that marks a descriptor as requestable. """
+    return lambda cls: adjust_defaults(cls, type_number=type_number, number=number)

--- a/facedancer/descriptor.py
+++ b/facedancer/descriptor.py
@@ -48,14 +48,20 @@ class USBDescribable(object):
 class USBDescriptor(USBDescribable, AutoInstantiable):
     """ Class for arbitrary USB descriptors; minimal concrete implementation of USBDescribable. """
 
-    raw         : bytes
+    """ The raw bytes of the descriptor. """
+    raw : bytes
 
-    type_number : int            = None
-    number      : int            = None
-    parent      : USBDescribable = None
+    """ The bDescriptorType of the descriptor. """
+    type_number : int = None
 
-    # Whether this descriptor should be included in a GET_CONFIGURATION response.
-    include_in_config : bool     = False
+    """ Number to request this descriptor with a GET_DESCRIPTOR request. """
+    number : int = None
+
+    """ Parent object which this descriptor is associated with. """
+    parent : USBDescribable = None
+
+    """ Whether this descriptor should be included in a GET_CONFIGURATION response. """
+    include_in_config : bool = False
 
     def __post_init__(self):
         # If type number was not set, get it from the raw bytes.

--- a/facedancer/descriptor.py
+++ b/facedancer/descriptor.py
@@ -57,6 +57,11 @@ class USBDescriptor(USBDescribable, AutoInstantiable):
     # Whether this descriptor should be included in a GET_CONFIGURATION response.
     include_in_config : bool     = False
 
+    def __post_init__(self):
+        # If type number was not set, get it from the raw bytes.
+        if self.type_number is None and self.raw is not None:
+            self.type_number = self.raw[1]
+
     def __call__(self, index=0):
         """ Converts the descriptor object into raw bytes. """
         return self.raw

--- a/facedancer/descriptor.py
+++ b/facedancer/descriptor.py
@@ -48,10 +48,10 @@ class USBDescribable(object):
 class USBDescriptor(USBDescribable, AutoInstantiable):
     """ Class for arbitrary USB descriptors; minimal concrete implementation of USBDescribable. """
 
-    number      : int
     raw         : bytes
 
     type_number : int            = None
+    number      : int            = None
     parent      : USBDescribable = None
 
     # Whether this descriptor should be included in a GET_CONFIGURATION response.

--- a/facedancer/descriptor.py
+++ b/facedancer/descriptor.py
@@ -3,15 +3,13 @@
 #
 """ Functionality for working with objects with associated USB descriptors. """
 
-from dataclasses import dataclass
-
-from .magic import AutoInstantiable
+from .magic import AutoInstantiable, DescribableMeta
 
 from enum import IntEnum
 from warnings import warn
 
 
-class USBDescribable(object):
+class USBDescribable(metaclass=DescribableMeta):
     """
     Abstract base class for objects that can be created from USB descriptors.
     """
@@ -44,7 +42,6 @@ class USBDescribable(object):
         return USBDescriptor.from_binary_descriptor(data, strings=strings)
 
 
-@dataclass
 class USBDescriptor(USBDescribable, AutoInstantiable):
     """ Class for arbitrary USB descriptors; minimal concrete implementation of USBDescribable. """
 
@@ -79,7 +76,7 @@ class USBDescriptor(USBDescribable, AutoInstantiable):
     def from_binary_descriptor(cls, data, strings={}):
         return USBDescriptor(raw=data, type_number=data[1], number=None)
 
-@dataclass
+
 class USBClassDescriptor(USBDescriptor):
     """ Class for arbitrary USB Class descriptors. """
 
@@ -93,7 +90,6 @@ class USBClassDescriptor(USBDescriptor):
         super().__init_subclass__(**kwargs)
 
 
-@dataclass
 class USBStringDescriptor(USBDescriptor):
     """ Class representing a USB string descriptor. """
 

--- a/facedancer/descriptor.py
+++ b/facedancer/descriptor.py
@@ -30,7 +30,7 @@ class USBDescribable(object):
 
 
     @classmethod
-    def from_binary_descriptor(cls, data):
+    def from_binary_descriptor(cls, data, strings={}):
         """
         Attempts to create a USBDescriptor subclass from the given raw
         descriptor data.
@@ -39,9 +39,9 @@ class USBDescribable(object):
         for subclass in cls.__subclasses__():
             # If this subclass handles our binary descriptor, use it to parse the given descriptor.
             if subclass.handles_binary_descriptor(data):
-                return subclass.from_binary_descriptor(data)
+                return subclass.from_binary_descriptor(data, strings=strings)
 
-        return USBDescriptor.from_binary_descriptor(data)
+        return USBDescriptor.from_binary_descriptor(data, strings=strings)
 
 
 @dataclass
@@ -65,7 +65,7 @@ class USBDescriptor(USBDescribable, AutoInstantiable):
         return (self.type_number, self.number)
 
     @classmethod
-    def from_binary_descriptor(cls, data):
+    def from_binary_descriptor(cls, data, strings={}):
         return USBDescriptor(raw=data, type_number=data[1], number=None)
 
 @dataclass

--- a/facedancer/device.py
+++ b/facedancer/device.py
@@ -13,7 +13,7 @@ import warnings
 import itertools
 
 from typing         import Coroutine, Dict, Iterable, Union
-from dataclasses    import dataclass, field
+from dataclasses    import field
 
 from prompt_toolkit import HTML, print_formatted_text
 
@@ -35,7 +35,6 @@ from .request       import standard_request_handler, to_device, get_request_hand
 from .logging       import log
 
 
-@dataclass
 class USBBaseDevice(USBDescribable, USBRequestHandler):
     """
     Base-most class for Facedancer USB devices. This version is very similar to the USBDevice type,

--- a/facedancer/device.py
+++ b/facedancer/device.py
@@ -93,7 +93,7 @@ class USBBaseDevice(USBDescribable, USBRequestHandler):
 
 
     @classmethod
-    def from_binary_descriptor(cls, data):
+    def from_binary_descriptor(cls, data, strings={}):
         """
         Creates a USBBaseDevice object from its descriptor.
         """
@@ -111,6 +111,15 @@ class USBBaseDevice(USBDescribable, USBRequestHandler):
                 manufacturer_string_index, product_string_index, \
                 serial_number_string_index, num_configurations = struct.unpack_from("<xxHBBBBHHHBBBB", data)
 
+        def lookup(string_index):
+            if string_index == 0:
+                return None
+            elif string_index in strings:
+                return strings[string_index]
+            else:
+                raise Exception(
+                    f"Missing string for string descriptor #{string_index}")
+
         device = cls(
             device_class=device_class,
             device_subclass=device_subclass,
@@ -118,9 +127,9 @@ class USBBaseDevice(USBDescribable, USBRequestHandler):
             max_packet_size_ep0=max_packet_size_ep0,
             vendor_id=vendor_id,
             product_id=product_id,
-            manufacturer_string=manufacturer_string_index,
-            product_string=product_string_index,
-            serial_number_string=serial_number_string_index,
+            manufacturer_string=lookup(manufacturer_string_index),
+            product_string=lookup(product_string_index),
+            serial_number_string=lookup(serial_number_string_index),
             device_revision=device_rev,
             usb_spec_version=spec_version,
         )

--- a/facedancer/endpoint.py
+++ b/facedancer/endpoint.py
@@ -65,7 +65,7 @@ class USBEndpoint(USBDescribable, AutoInstantiable, USBRequestHandler):
 
 
     @classmethod
-    def from_binary_descriptor(cls, data):
+    def from_binary_descriptor(cls, data, strings={}):
         """
         Creates an endpoint object from a description of that endpoint.
         """

--- a/facedancer/endpoint.py
+++ b/facedancer/endpoint.py
@@ -82,10 +82,10 @@ class USBEndpoint(USBDescribable, AutoInstantiable, USBRequestHandler):
 
         return cls(
             number=number,
-            direction=direction,
-            transfer_type=transfer_type,
-            synchronization_type=sync_type,
-            usage_type=usage_type,
+            direction=USBDirection(direction),
+            transfer_type=USBTransferType(transfer_type),
+            synchronization_type=USBSynchronizationType(sync_type),
+            usage_type=USBUsageType(usage_type),
             max_packet_size=max_packet_size,
             interval=interval,
             extra_bytes=data[7:]

--- a/facedancer/endpoint.py
+++ b/facedancer/endpoint.py
@@ -9,7 +9,8 @@ from __future__  import annotations
 import struct
 
 from typing      import Iterable, List, Dict
-from dataclasses import dataclass, field
+from dataclasses import field
+from collections import defaultdict
 
 from .magic      import AutoInstantiable, instantiate_subordinates
 from .descriptor import USBDescribable, USBDescriptor
@@ -21,7 +22,6 @@ from .types      import USBUsageType, USBStandardRequests
 from .logging    import log
 
 
-@dataclass
 class USBEndpoint(USBDescribable, AutoInstantiable, USBRequestHandler):
     """ Class representing a USBEndpoint object.
 

--- a/facedancer/interface.py
+++ b/facedancer/interface.py
@@ -16,7 +16,7 @@ from .magic       import instantiate_subordinates, AutoInstantiable
 from .types       import USBDirection, USBStandardRequests
 
 from .            import device
-from .descriptor  import USBDescribable, USBDescriptor, USBClassDescriptor, USBDescriptorTypeNumber
+from .descriptor  import USBDescribable, USBDescriptor, USBClassDescriptor, USBDescriptorTypeNumber, StringRef
 from .request     import USBControlRequest, USBRequestHandler, get_request_handler_methods
 from .request     import standard_request_handler, to_this_interface
 from .endpoint    import USBEndpoint
@@ -37,7 +37,7 @@ class USBInterface(USBDescribable, AutoInstantiable, USBRequestHandler):
     """
     DESCRIPTOR_TYPE_NUMBER = 0x4
 
-    name                   : str = "generic USB interface"
+    name                   : StringRef = StringRef.field(string="generic USB interface")
 
     number                 : int = 0
     alternate              : int = 0
@@ -73,11 +73,13 @@ class USBInterface(USBDescribable, AutoInstantiable, USBRequestHandler):
             class_number=interface_class,
             subclass_number=interface_subclass,
             protocol_number=interface_protocol,
-            interface_string=None if string_index == 0 else strings[string_index]
+            interface_string=StringRef.lookup(strings, string_index)
         )
 
 
     def __post_init__(self):
+
+        self.interface_string = StringRef.ensure(self.interface_string)
 
         # Capture any descriptors/endpoints declared directly on the class.
         for endpoint in instantiate_subordinates(self, USBEndpoint):

--- a/facedancer/interface.py
+++ b/facedancer/interface.py
@@ -9,7 +9,8 @@ from __future__  import annotations
 import struct
 
 from typing       import Dict, List, Iterable
-from dataclasses  import dataclass, field
+from dataclasses  import field
+from collections  import defaultdict
 
 from .magic       import instantiate_subordinates, AutoInstantiable
 from .types       import USBDirection, USBStandardRequests
@@ -23,7 +24,6 @@ from .endpoint    import USBEndpoint
 from .logging     import log
 
 
-@dataclass
 class USBInterface(USBDescribable, AutoInstantiable, USBRequestHandler):
     """ Class representing a USBDevice interface.
 

--- a/facedancer/interface.py
+++ b/facedancer/interface.py
@@ -59,12 +59,12 @@ class USBInterface(USBDescribable, AutoInstantiable, USBRequestHandler):
 
 
     @classmethod
-    def from_binary_descriptor(cls, data):
+    def from_binary_descriptor(cls, data, strings={}):
         """
         Generates an interface object from a descriptor.
         """
         interface_number, alternate_setting, num_endpoints, interface_class, \
-                interface_subclass, interface_protocol, interface_string_index \
+                interface_subclass, interface_protocol, string_index \
                 = struct.unpack_from("xxBBBBBBB", data)
         return cls(
             name=None,
@@ -73,7 +73,7 @@ class USBInterface(USBDescribable, AutoInstantiable, USBRequestHandler):
             class_number=interface_class,
             subclass_number=interface_subclass,
             protocol_number=interface_protocol,
-            interface_string=interface_string_index
+            interface_string=None if string_index == 0 else strings[string_index]
         )
 
 

--- a/facedancer/magic.py
+++ b/facedancer/magic.py
@@ -23,6 +23,15 @@ class DescribableMeta(ABCMeta):
         return dataclass(new_cls, kw_only=True)
 
 
+def adjust_defaults(cls, **kwargs):
+    """ Adjusts the defaults of an existing dataclass. """
+    assert is_dataclass(cls)
+    for name, value in kwargs.items():
+        cls.__dataclass_fields__[name] = field(default = value)
+        cls.__init__.__kwdefaults__[name] = value
+    return cls
+
+
 class AutoInstantiable(metaclass=DescribableMeta):
     """ Base class for methods that can be decorated with use_automatically. """
 

--- a/facedancer/magic.py
+++ b/facedancer/magic.py
@@ -31,21 +31,14 @@ class AutoInstantiator:
     at the cost of being somewhat cryptic.
     """
 
-    def __init__(self, target_type, identifier=None):
+    def __init__(self, target_type):
         self._target_type = target_type
-        self._identifier  = identifier
 
     def creates_instance_of(self, expected_type):
         return issubclass(self._target_type, expected_type)
 
     def __call__(self, parent):
-        instance   = self._target_type(parent=parent)
-        identifier = self._identifier
-
-        if identifier is None:
-            identifier = instance.get_identifier()
-
-        return identifier, instance
+        return self._target_type(parent=parent)
 
 
 def use_automatically(cls):
@@ -108,14 +101,7 @@ def instantiate_subordinates(obj, expected_type):
     objects of any inner class decorated with ``@use_automatically``.
     """
 
-    instances = {}
-
     # Search our class for anything decorated with an AutoInstantiator of the relevant type.
     for _, member in inspect.getmembers(obj):
         if isinstance(member, AutoInstantiator) and member.creates_instance_of(expected_type):
-
-            # And instantiate it.
-            identifier, target = member(obj)
-            instances[identifier] = target
-
-    return instances
+            yield member(object)

--- a/facedancer/magic.py
+++ b/facedancer/magic.py
@@ -74,7 +74,7 @@ def use_automatically(cls):
 
 def _use_inner_classes_automatically(cls):
     # Iterate over the relevant class...
-    for name, member in inspect.getmembers(cls):
+    for name, member in cls.__dict__.items():
 
         # ... and tag each inner class with both use_automatically
         # -and- use_inner_classes_automatically. The former
@@ -102,6 +102,6 @@ def instantiate_subordinates(obj, expected_type):
     """
 
     # Search our class for anything decorated with an AutoInstantiator of the relevant type.
-    for _, member in inspect.getmembers(obj):
+    for member in type(obj).__dict__.values():
         if isinstance(member, AutoInstantiator) and member.creates_instance_of(expected_type):
             yield member(object)


### PR DESCRIPTION
This PR collects followup changes that build on the descriptor API work from #126.

Key changes are:
- Descriptors attached to endpoints are now instantiated (replaces #139)
- The `instantiate_subordinates` function is redesigned to avoid silent dropping of subordinates with duplicate identifiers (replaces #140).
- Orderings of declaration/insertion of subordinates are preserved, allowing control of ordering in binary configurations.
- Fixes to convert some fields to the right types in `from_binary_descriptor` methods.
- A dictionary of known strings and their indexes may be passed to `from_binary_descriptor` methods.
- The `number` field of `USBDescriptor` is made optional, as it is not required for descriptors attached in a configuration.
- The `type_number` field will now be inferred from the `raw` bytes if not otherwise specified.
- Add `@include_in_config` and `@requestable(number=N)` decorators for use on declared descriptor classes.
- Add docstrings for all `USBDescriptor` fields.