### PR TITLE
Update Python versions: drop 3.8, 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "facedancer"
 description = "Implement your own USB device in Python, supported by a hardware peripheral such as Cynthion or GreatFET."
 license = { text = "BSD" }
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     {name = "Great Scott Gadgets", email = "dev@greatscottgadgets.com"},
 ]


### PR DESCRIPTION
This PR:

* Drops support for Python 3.8 as it has reached end of life. 
* Drops support for Python 3.9 as it does not support the `kw_only` parameter for `dataclass`.

For more information see: #145 #149

---
Closes #145 