### PR TITLE
Give more descriptors access to the descriptor tree

### DIFF
--- a/facedancer/device.py
+++ b/facedancer/device.py
@@ -202,6 +202,7 @@ class USBBaseDevice(USBDescribable, USBRequestHandler):
 
         else:
             self.requestable_descriptors[identifier] = descriptor
+            descriptor.parent = self
 
 
     def connect(self, device_speed: DeviceSpeed=DeviceSpeed.FULL):

--- a/facedancer/endpoint.py
+++ b/facedancer/endpoint.py
@@ -190,6 +190,7 @@ class USBEndpoint(USBDescribable, AutoInstantiable, USBRequestHandler):
 
         if descriptor.include_in_config:
             self.attached_descriptors.append(descriptor)
+            descriptor.parent = self
 
         elif descriptor.number is None:
             raise Exception(

--- a/facedancer/interface.py
+++ b/facedancer/interface.py
@@ -148,6 +148,7 @@ class USBInterface(USBDescribable, AutoInstantiable, USBRequestHandler):
 
         if descriptor.include_in_config:
             self.attached_descriptors.append(descriptor)
+            descriptor.parent = self
 
         elif descriptor.number is None:
             raise Exception(


### PR DESCRIPTION
Hi,

While creating new devices, I needed to access members from other descriptors like in the example below:

```python
@use_inner_classes_automatically
class Device(USBDevice):
    class DeviceConfiguration(USBConfiguration):
        class DeviceInterface(USBInterface):
            number                 : int = 0

            @include_in_config
            class CustomDescriptor(USBDescriptor):
                raw : bytes = bytes()

                def __call__(self, index=0):
                    """ Converts the descriptor object into raw bytes. """
                    device = self.parent.parent.parent
                    self.raw = bytes([
                        device.somefield
                    ])
                    return super().__call__(index)
```

This specific descriptor was not given a parent (because of the ` include_in_config` ) so I'm proposing these fixes to adopt more descriptors and give a parent to all of them.

Best,

